### PR TITLE
Make Emulated MT32 louder

### DIFF
--- a/Boxer/BXEmulatedMT32.mm
+++ b/Boxer/BXEmulatedMT32.mm
@@ -413,7 +413,7 @@ void _logMT32DebugMessage(void *userData, const char *fmt, va_list list);
     }
     
     // Make sure MT32 is loud enough.
-    // 9.0 seems to be about right with SoundBlaster sfx
+    // 5.0 seems to be about right with SoundBlaster sfx
     _synth->setOutputGain(5.0f);
     
     return YES;


### PR DESCRIPTION
Emulated MT32 is way too quiet when played with SoundBlaster SFX, and
there's no way to change it independently. This will increase the output gain so
that it's about the same as the SoundBlaster levels.
