### PR TITLE
With the numpad simulation on, make original keys "below" the numpad simulation accessible with Fn

### DIFF
--- a/Boxer/DOS window/BXInputController+BXKeyboardInput.m
+++ b/Boxer/DOS window/BXInputController+BXKeyboardInput.m
@@ -105,9 +105,11 @@
 		[self.representedObject resume: self];
         
         //Check the separate key-mapping layer for numpad simulation for this key,
-        //if the numpad simulation toggle is on or the user is holding down the Fn key.
+        //if the numpad simulation toggle is on XOR the user is holding down the Fn key.
+        //Why XOR? Then, with the simulation toggle on, the original keys "below" the
+        //numpad simulation can be accessed by holding the Fn key. (!= is logical XOR)
         BOOL fnModified = (theEvent.modifierFlags & NSFunctionKeyMask) == NSFunctionKeyMask;
-        BOOL simulateNumpad = self.simulatedNumpadActive || fnModified;
+        BOOL simulateNumpad = self.simulatedNumpadActive != fnModified;
         
         CGKeyCode OSXKeyCode = theEvent.keyCode;
         BXDOSKeyCode dosKeyCode = KBD_NONE;


### PR DESCRIPTION
"Bioforge" needs the numpad simulation but the keys "i" and "l" are needed, too.
Before, one needed to disable the simulation to use these keys.
After this patch, the numpad simulation can be temporarily disabled by holding Fn.
