### PR TITLE
Fix hang when regenerating gamebox icon

### DIFF
--- a/Boxer/BXSession.m
+++ b/Boxer/BXSession.m
@@ -1092,7 +1092,7 @@ NSString * const BXGameImportedNotificationType     = @"BXGameImported";
 }
 
 + (NSSet *) keyPathsForValuesAffectingHasGamebox        { return [NSSet setWithObject: @"gamebox"]; }
-+ (NSSet *) keyPathsForValuesAffectingRepresentedIcon	{ return [NSSet setWithObjects: @"gamebox", @"gamebox.coverArt", nil]; }
++ (NSSet *) keyPathsForValuesAffectingRepresentedIcon	{ return [NSSet setWithObject: @"gamebox"]; }
 + (NSSet *) keyPathsForValuesAffectingCurrentURL        { return [NSSet setWithObjects: @"launchedProgramURL", @"emulator.currentDirectoryURL", nil]; }
 
 - (NSArray *) recentPrograms


### PR DESCRIPTION
This PR fixes a regression in the custom icon check that triggered a hang when launching any gamebox.

### Explanation

As of https://github.com/alunbestor/Boxer/commit/4f0ed18f8a16597e44301a8d8b8fab485e032c36, `NSWorkspace.URLHasCustomIcon` started reporting NO for all files. This is because Apple's newer APIs for testing whether a file/folder has a custom icon are broken and have never worked; while their older Carbon-era APIs are deprecated as fuck.

Because of this regression, gameboxes would always claim they had no icon. Because of some poorly-thought-out KVO code, Boxer would then continually attempt to regenerate the icon:
`BXSession.representedIcon` will attempt to generate a new icon and save it to `BXSession.representedIcon.gamebox.coverArt`. Meanwhile, `BXSession.representedIcon.gamebox.coverArt` was reported as a key path that affected `BXSession.representedIcon`, so setting it inadvertently triggered a new KVO notification saying that `representedIcon` had changed while it was in the process of being accessed, which caused an infinite recursion in another place that was observing `representedIcon`.

This is why I hate KVO.

Anyway, this PR tweaks the KVO to prevent the infinite loop, and also fixes the icon check by replacing the looks-like-it-ought-to-work-but-doesn't check with a less thorough approach that sniffs for the presence of a custom icon file. This should be good enough in 95% of cases and avoids leaving deprecated code around the place.