### PR TITLE
Code cleanup: property attributes and manual property synthesis

### DIFF
--- a/Boxer/Application Delegate/BXBaseAppController+BXHotKeys.m
+++ b/Boxer/Application Delegate/BXBaseAppController+BXHotKeys.m
@@ -154,7 +154,7 @@
     //When we first set up the tap at application startup, check if Boxer already has permission to capture hotkeys.
     //We use this later to determine whether Boxer has been granted that permission while it's running,
     //and hence whether we may need to restart in order for those permissions to take effect.
-    _couldCaptureHotkeysAtStartup = self.canCaptureHotkeys;
+    self.couldCaptureHotkeysAtStartup = self.canCaptureHotkeys;
     
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     
@@ -222,7 +222,7 @@
         //tap at all even though the API reports that we have permission to do so (which would otherwise
         //cause us to enter a continual restart loop as we keep thinking we're just a restart away from
         //those permissions taking effect.)
-		BOOL permissionGrantedThisSession = self.canCaptureHotkeys && !self->_couldCaptureHotkeysAtStartup;
+        BOOL permissionGrantedThisSession = self.canCaptureHotkeys && !self.couldCaptureHotkeysAtStartup;
         
         self.needsRestartForHotkeyCapture = (tap.status != BXKeyboardEventTapTappingAllKeyboardEvents) && permissionGrantedThisSession;
         

--- a/Boxer/Application Delegate/BXBaseAppController.h
+++ b/Boxer/Application Delegate/BXBaseAppController.h
@@ -18,23 +18,6 @@
 /// the standard and standalone app controller subclasses. It is not intended to be instantiated directly.
 @interface BXBaseAppController : NSDocumentController <NSApplicationDelegate, NSAlertDelegate>
 
-{
-	BXSession *_currentSession;
-	NSOperationQueue *_generalQueue;
-	
-    BXJoystickController *_joystickController;
-    BXJoypadController *_joypadController;
-    
-    BXMIDIDeviceMonitor *_MIDIDeviceMonitor;
-    
-    void (^_postTerminationHandler)(void);
-    
-    BXKeyboardEventTap *_hotkeySuppressionTap;
-    NSAlert *_activeHotkeyAlert;
-    BOOL _couldCaptureHotkeysAtStartup;
-    BOOL _needsRestartForHotkeyCapture;
-}
-
 #pragma mark - Properties
 
 /// The currently-active DOS session. Changes whenever a new session opens.

--- a/Boxer/Application Delegate/BXBaseAppController.m
+++ b/Boxer/Application Delegate/BXBaseAppController.m
@@ -42,18 +42,6 @@
 
 @implementation BXBaseAppController
 
-@synthesize currentSession = _currentSession;
-@synthesize generalQueue = _generalQueue;
-@synthesize joystickController = _joystickController;
-@synthesize joypadController = _joypadController;
-@synthesize MIDIDeviceMonitor = _MIDIDeviceMonitor;
-@synthesize hotkeySuppressionTap = _hotkeySuppressionTap;
-
-@synthesize postTerminationHandler = _postTerminationHandler;
-@synthesize activeHotkeyAlert = _activeHotkeyAlert;
-@synthesize needsRestartForHotkeyCapture = _needsRestartForHotkeyCapture;
-
-
 #pragma mark - Helper class methods
 
 + (NSString *) localizedVersion

--- a/Boxer/Application Delegate/BXBaseAppControllerPrivate.h
+++ b/Boxer/Application Delegate/BXBaseAppControllerPrivate.h
@@ -12,6 +12,10 @@
 /// Private API for BXAppController which should only be accessed by subclasses.
 @interface BXBaseAppController ()
 
+/// Whether Boxer was able to capture hotkeys at application startup time.
+/// This is used to detect whether permission was successfully granted during the current application session, in which case a restart is required for to take full effect.
+@property (nonatomic) BOOL couldCaptureHotkeysAtStartup;
+
 /// A block to run once the application has finished terminating. Used by @c -terminateWithHandler:.
 @property (copy, nonatomic) void(^postTerminationHandler)(void);
 

--- a/Boxer/Application Delegate/BXSampleGamesCopy.m
+++ b/Boxer/Application Delegate/BXSampleGamesCopy.m
@@ -10,8 +10,6 @@
 #import "BXCoverArt.h"
 
 @implementation BXSampleGamesCopy
-@synthesize sourceURL = _sourceURL;
-@synthesize targetURL = _targetURL;
 
 - (id) initFromSourceURL: (NSURL *)sourceURL toTargetURL: (NSURL *)targetURL
 {

--- a/Boxer/Application Delegate/BXShelfAppearanceOperation.h
+++ b/Boxer/Application Delegate/BXShelfAppearanceOperation.h
@@ -16,12 +16,7 @@
 /// appearance from Finder folders. This means interacting with Finder via the Scripting
 /// Bridge API, which is slow, so we do this work as a background operation.
 @interface BXShelfAppearanceOperation : NSOperation
-{
-	NSURL *_targetURL;
-	BOOL _appliesToSubFolders;
-	
-	FinderApplication *_finder;
-}
+
 @property (copy) NSURL *targetURL;
 @property (assign) BOOL appliesToSubFolders;
 
@@ -29,13 +24,6 @@
 
 
 @interface BXShelfAppearanceApplicator : BXShelfAppearanceOperation
-{
-	NSImage *_icon;
-	NSURL *_backgroundImageURL;
-	BOOL _switchToIconView;
-	
-	FinderFile *_backgroundPicture;
-}
 
 @property (copy) NSURL *backgroundImageURL;
 @property (copy) NSImage *icon;
@@ -48,11 +36,6 @@
 
 
 @interface BXShelfAppearanceRemover: BXShelfAppearanceOperation
-{
-	NSURL *_sourceURL;
-	
-	FinderIconViewOptions *_sourceOptions;
-}
 
 @property (copy) NSURL *sourceURL;
 

--- a/Boxer/Application Delegate/BXShelfAppearanceOperation.m
+++ b/Boxer/Application Delegate/BXShelfAppearanceOperation.m
@@ -27,9 +27,6 @@
 
 
 @implementation BXShelfAppearanceOperation
-@synthesize finder = _finder;
-@synthesize targetURL = _targetURL;
-@synthesize appliesToSubFolders = _appliesToSubFolders;
 
 - (instancetype) init
 {
@@ -108,10 +105,6 @@
 @end
 
 @implementation BXShelfAppearanceApplicator
-@synthesize backgroundImageURL = _backgroundImageURL;
-@synthesize icon = _icon;
-@synthesize switchToIconView = _switchToIconView;
-@synthesize backgroundPicture = _backgroundPicture;
 
 - (id) initWithTargetURL: (NSURL *)targetURL
 	  backgroundImageURL: (NSURL *)backgroundImageURL
@@ -190,8 +183,6 @@
 @end
 
 @implementation BXShelfAppearanceRemover
-@synthesize sourceURL = _sourceURL;
-@synthesize sourceOptions = _sourceOptions;
 
 - (id) initWithTargetURL: (NSURL *)targetURL
        appearanceFromURL: (NSURL *)sourceURL

--- a/Boxer/BXAboutController.h
+++ b/Boxer/BXAboutController.h
@@ -10,9 +10,7 @@
 
 /// \c BXAboutController is a simple window controller which styles and displays the About Boxer panel.
 @interface BXAboutController : NSWindowController
-{
-	NSTextField *_version;
-}
+
 @property (strong, nonatomic) IBOutlet NSTextField *version;
 
 /// Provides a singleton instance of the window controller which stays retained for the lifetime

--- a/Boxer/BXAboutController.m
+++ b/Boxer/BXAboutController.m
@@ -10,7 +10,6 @@
 
 
 @implementation BXAboutController
-@synthesize version = _version;
 
 + (id) controller
 {

--- a/Boxer/BXBezelController.h
+++ b/Boxer/BXBezelController.h
@@ -37,83 +37,56 @@ enum {
 @class BXGamebox;
 /// BXBezelController is a singleton that manages a translucent notification bezel.
 @interface BXBezelController : NSWindowController
-{
-    NSView *__weak _driveAddedBezel;
-    NSView *__weak _driveSwappedBezel;
-    NSView *__weak _driveRemovedBezel;
-    NSView *__weak _driveImportedBezel;
-    NSView *__weak _fullscreenBezel;
-    NSView *__weak _joystickIgnoredBezel;
-    NSView *__weak _CPUSpeedBezel;
-    NSView *__weak _throttleBezel;
-    NSView *__weak _volumeBezel;
-    NSView *__weak _pauseBezel;
-    NSView *__weak _playBezel;
-    NSView *__weak _fastForwardBezel;
-    NSView *__weak _screenshotBezel;
-    NSView *__weak _MT32MessageBezel;
-    NSView *__weak _MT32MissingBezel;
-    NSView *__weak _numpadActiveBezel;
-    NSView *__weak _numpadInactiveBezel;
-    NSView *__weak _numlockActiveBezel;
-    NSView *__weak _numlockInactiveBezel;
-    
-    NSView *__weak _mouseLockedBezel;
-    
-    BXBezelPriority _currentPriority;
-    
-    BOOL _hasShownFullscreenBezel;
-}
 
 #pragma mark -
 #pragma mark Properties
 
 /// The bezel view used for drive inserted/ejected/imported notifications.
-@property (weak, nonatomic) IBOutlet NSView *driveAddedBezel;
-@property (weak, nonatomic) IBOutlet NSView *driveSwappedBezel;
-@property (weak, nonatomic) IBOutlet NSView *driveRemovedBezel;
-@property (weak, nonatomic) IBOutlet NSView *driveImportedBezel;
+@property (strong, nonatomic) IBOutlet NSView *driveAddedBezel;
+@property (strong, nonatomic) IBOutlet NSView *driveSwappedBezel;
+@property (strong, nonatomic) IBOutlet NSView *driveRemovedBezel;
+@property (strong, nonatomic) IBOutlet NSView *driveImportedBezel;
 
 /// The bezel used for fullscreen toggle notifications.
-@property (weak, nonatomic) IBOutlet NSView *fullscreenBezel;
+@property (strong, nonatomic) IBOutlet NSView *fullscreenBezel;
 
 /// The bezel used for notifying the user that the joystick is being ignored.
-@property (weak, nonatomic) IBOutlet NSView *joystickIgnoredBezel;
+@property (strong, nonatomic) IBOutlet NSView *joystickIgnoredBezel;
 
 /// The bezel view used for CPU speed notifications.
-@property (weak, nonatomic) IBOutlet NSView *CPUSpeedBezel;
+@property (strong, nonatomic) IBOutlet NSView *CPUSpeedBezel;
 
 /// The bezel view used for flightstick throttle notifications.
-@property (weak, nonatomic) IBOutlet NSView *throttleBezel;
+@property (strong, nonatomic) IBOutlet NSView *throttleBezel;
 
 /// The bezel view used for volume notifications.
-@property (weak, nonatomic) IBOutlet NSView *volumeBezel;
+@property (strong, nonatomic) IBOutlet NSView *volumeBezel;
 
 /// The bezel view used for MT-32 LCD messages.
-@property (weak, nonatomic) IBOutlet NSView *MT32MessageBezel;
+@property (strong, nonatomic) IBOutlet NSView *MT32MessageBezel;
 /// The bezel view used for notifying the user that they need an MT-32 to hear proper music.
-@property (weak, nonatomic) IBOutlet NSView *MT32MissingBezel;
+@property (strong, nonatomic) IBOutlet NSView *MT32MissingBezel;
 
 /// Screenshot bezel views.
-@property (weak, nonatomic) IBOutlet NSView *screenshotBezel;
+@property (strong, nonatomic) IBOutlet NSView *screenshotBezel;
 
 /// Pause/play/fast-forward bezel views.
-@property (weak, nonatomic) IBOutlet NSView *pauseBezel;
-@property (weak, nonatomic) IBOutlet NSView *playBezel;
-@property (weak, nonatomic) IBOutlet NSView *fastForwardBezel;
+@property (strong, nonatomic) IBOutlet NSView *pauseBezel;
+@property (strong, nonatomic) IBOutlet NSView *playBezel;
+@property (strong, nonatomic) IBOutlet NSView *fastForwardBezel;
 
 /// Numpad simulation bezels.
-@property (weak, nonatomic) IBOutlet NSView *numpadActiveBezel;
-@property (weak, nonatomic) IBOutlet NSView *numpadInactiveBezel;
+@property (strong, nonatomic) IBOutlet NSView *numpadActiveBezel;
+@property (strong, nonatomic) IBOutlet NSView *numpadInactiveBezel;
 
 /// Numlock toggle bezels.
-@property (weak, nonatomic) IBOutlet NSView *numlockActiveBezel;
-@property (weak, nonatomic) IBOutlet NSView *numlockInactiveBezel;
+@property (strong, nonatomic) IBOutlet NSView *numlockActiveBezel;
+@property (strong, nonatomic) IBOutlet NSView *numlockInactiveBezel;
 
-@property (weak, nonatomic) IBOutlet NSView *mouseLockedBezel;
+@property (strong, nonatomic) IBOutlet NSView *mouseLockedBezel;
 
 /// The last bezel that was displayed.
-@property (weak, readonly, nonatomic) NSView *currentBezel;
+@property (readonly, nonatomic, nullable) NSView *currentBezel;
 
 #pragma mark -
 #pragma mark Class methods

--- a/Boxer/BXBezelController.m
+++ b/Boxer/BXBezelController.m
@@ -41,35 +41,10 @@
 #define BXMouseLockedBezelDuration 1.5
 
 @implementation BXBezelController
-
-@synthesize driveAddedBezel = _driveAddedBezel;
-@synthesize driveRemovedBezel = _driveRemovedBezel;
-@synthesize driveSwappedBezel = _driveSwappedBezel;
-@synthesize driveImportedBezel = _driveImportedBezel;
-
-@synthesize pauseBezel = _pauseBezel;
-@synthesize playBezel = _playBezel;
-@synthesize fastForwardBezel = _fastForwardBezel;
-
-@synthesize fullscreenBezel = _fullscreenBezel;
-@synthesize screenshotBezel = _screenshotBezel;
-
-@synthesize CPUSpeedBezel = _CPUSpeedBezel;
-@synthesize volumeBezel = _volumeBezel;
-
-@synthesize throttleBezel = _throttleBezel;
-@synthesize joystickIgnoredBezel = _joystickIgnoredBezel;
-
-@synthesize MT32MessageBezel = _MT32MessageBezel;
-@synthesize MT32MissingBezel = _MT32MissingBezel;
-
-@synthesize numpadActiveBezel = _numpadActiveBezel;
-@synthesize numpadInactiveBezel = _numpadInactiveBezel;
-@synthesize numlockActiveBezel = _numlockActiveBezel;
-@synthesize numlockInactiveBezel = _numlockInactiveBezel;
-
-@synthesize mouseLockedBezel = _mouseLockedBezel;
-
+{
+	BXBezelPriority _currentPriority;	
+	BOOL _hasShownFullscreenBezel;
+}
 
 + (NSImage *) bezelIconForDrive: (BXDrive *)drive
 {

--- a/Boxer/BXBinCueImageImport.h
+++ b/Boxer/BXBinCueImageImport.h
@@ -11,12 +11,9 @@
 /// \c BXBinCueImageImport rips CD-ROM discs to BIN/CUE images that are bundled into a .cdmedia bundle,
 /// using the cdrdao utility.
 @interface BXBinCueImageImport : BXCDImageImport
-{	
-	@protected
-	BOOL _usesErrorCorrection;
-}
+
 /// Enables/disables cdrdao's error-correction when reading audio tracks.
 /// This halves the speed of importing when enabled.
-@property (assign) BOOL usesErrorCorrection;
+@property (atomic) BOOL usesErrorCorrection;
 
 @end

--- a/Boxer/BXBinCueImageImport.m
+++ b/Boxer/BXBinCueImageImport.m
@@ -76,9 +76,7 @@ BOOL _mountSynchronously(DASessionRef session, DADiskRef disk, CFURLRef path, DA
 	return status == BXDADiskOperationSucceeded;
 }
 
-
 @implementation BXBinCueImageImport
-@synthesize usesErrorCorrection = _usesErrorCorrection;
 
 + (BOOL) driveUnavailableDuringImport
 {
@@ -142,7 +140,7 @@ BOOL _mountSynchronously(DASessionRef session, DADiskRef disk, CFURLRef path, DA
     if (!self.destinationURL)
         self.destinationURL = self.preferredDestinationURL;
     
-    _hasWrittenFiles = NO;
+    self.hasWrittenFiles = NO;
     
 	NSURL *sourceURL		= self.drive.sourceURL;
 	NSURL *destinationURL	= self.destinationURL;
@@ -225,7 +223,7 @@ BOOL _mountSynchronously(DASessionRef session, DADiskRef disk, CFURLRef path, DA
 	
 	//At this point we have started creating data; record this fact so that we will
 	//clean up our partial files in BXCDImageImport -undoTransfer if the import is aborted.
-	_hasWrittenFiles = YES;
+	self.hasWrittenFiles = YES;
 
 	
 	//Unmount the disc's volume without ejecting it, so that cdrdao can access the device exclusively.

--- a/Boxer/BXBootlegCoverArt.h
+++ b/Boxer/BXBootlegCoverArt.h
@@ -16,8 +16,8 @@
 /// Return a new BXBootlegCoverArt implementor using the specified title.
 - (instancetype) initWithTitle: (NSString *)coverTitle;
 
-/// Set and get the title which this cover art will display.
-@property (readwrite, copy) NSString *title;
+/// The game title to display on this cover art.
+@property (copy, nonatomic) NSString *title;
 
 /// Draws the source image as cover art into the specified frame in the current graphics context.
 - (void) drawInRect: (NSRect)frame;
@@ -35,10 +35,9 @@
 
 
 @interface BXJewelCase : NSObject <BXBootlegCoverArt>
-{
-	NSString *title;
-}
-@property (copy) NSString *title;
+
+/// The game title to display on this cover art.
+@property (copy, nonatomic) NSString *title;
 
 /// Returns the font family name used for printing the title.
 + (NSString *) fontName;

--- a/Boxer/BXBootlegCoverArt.m
+++ b/Boxer/BXBootlegCoverArt.m
@@ -10,7 +10,6 @@
 #import "ADBAppKitVersionHelpers.h"
 
 @implementation BXJewelCase
-@synthesize title;
 
 + (NSString *) fontName	{ return @"Marker Felt Thin"; }
 

--- a/Boxer/BXCDImageImport.h
+++ b/Boxer/BXCDImageImport.h
@@ -21,22 +21,13 @@ typedef NS_ERROR_ENUM(BXCDImageImportErrorDomain, BXCDImageImportErrors) {
 
 /// BXCDImageImport rips physical CDs to (CDR-format) ISO disc images using OS X's hdiutil.
 @interface BXCDImageImport : ADBTaskOperation <BXDriveImport>
-{
-	BXDrive *_drive;
-	unsigned long long _numBytes;
-	unsigned long long _bytesTransferred;
-	ADBOperationProgress _currentProgress;
-	BOOL _indeterminate;
-	NSURL *_destinationFolderURL;
-	NSURL *_destinationURL;
-    BOOL _hasWrittenFiles;
-}
 
-@property (assign, readwrite) unsigned long long numBytes;
-@property (assign, readwrite) unsigned long long bytesTransferred;
-@property (assign, readwrite) ADBOperationProgress currentProgress;
-@property (assign, readwrite, getter=isIndeterminate) BOOL indeterminate;
+@property (atomic) unsigned long long numBytes;
+@property (atomic) unsigned long long bytesTransferred;
+@property (atomic) ADBOperationProgress currentProgress;
+@property (atomic, getter=isIndeterminate) BOOL indeterminate;
 
+@property (atomic) BOOL hasWrittenFiles;
 
 @end
 

--- a/Boxer/BXCDImageImport.m
+++ b/Boxer/BXCDImageImport.m
@@ -20,14 +20,10 @@ NSString * const BXCDImageImportErrorDomain = @"BXCDImageImportErrorDomain";
 #pragma mark Implementations
 
 @implementation BXCDImageImport
+
 @synthesize drive = _drive;
 @synthesize destinationFolderURL	= _destinationFolderURL;
 @synthesize destinationURL          = _destinationURL;
-
-@synthesize numBytes			= _numBytes;
-@synthesize bytesTransferred	= _bytesTransferred;
-@synthesize currentProgress		= _currentProgress;
-@synthesize indeterminate		= _indeterminate;
 
 
 #pragma mark -
@@ -194,9 +190,9 @@ NSString * const BXCDImageImportErrorDomain = @"BXCDImageImportErrorDomain";
 	self.task = hdiutil;
 	
 	//Run the task to completion and monitor its progress
-    _hasWrittenFiles = NO;
+    self.hasWrittenFiles = NO;
 	[super main];
-    _hasWrittenFiles = YES;
+    self.hasWrittenFiles = YES;
 	
 	if (!self.error)
 	{
@@ -268,7 +264,7 @@ NSString * const BXCDImageImportErrorDomain = @"BXCDImageImportErrorDomain";
 - (BOOL) undoTransfer
 {
 	BOOL undid = NO;
-	if (self.destinationURL && _hasWrittenFiles)
+	if (self.destinationURL && self.hasWrittenFiles)
 	{
         undid = [[NSFileManager defaultManager] removeItemAtURL: self.destinationURL error: NULL];
 	}

--- a/Boxer/BXCollectionItemView.h
+++ b/Boxer/BXCollectionItemView.h
@@ -25,8 +25,8 @@
 
 @interface BXCollectionItemView : NSView
 
-//A weak reference back to the collection view item we represent.
-@property (weak, nonatomic) IBOutlet NSCollectionViewItem *delegate;
+/// The collection view item represented by this view.
+@property (unsafe_unretained, nonatomic) IBOutlet NSCollectionViewItem *delegate;
 
 /// The view prototype we were copied from.
 @property (readonly, nonatomic) NSView *prototype;

--- a/Boxer/BXCollectionItemView.h
+++ b/Boxer/BXCollectionItemView.h
@@ -24,14 +24,12 @@
 
 
 @interface BXCollectionItemView : NSView
-{
-	__unsafe_unretained NSCollectionViewItem *_delegate;
-}
-/// A nonretained reference back to the collection view item we represent.
-@property (assign, nonatomic) IBOutlet NSCollectionViewItem *delegate;
+
+//A weak reference back to the collection view item we represent.
+@property (weak, nonatomic) IBOutlet NSCollectionViewItem *delegate;
 
 /// The view prototype we were copied from.
-@property (weak, readonly, nonatomic) NSView *prototype;
+@property (readonly, nonatomic) NSView *prototype;
 
 /// Called by BXCollectionItem when the item's selected status changes.
 /// By default, flags the view as needing to be displayed.

--- a/Boxer/BXCollectionItemView.m
+++ b/Boxer/BXCollectionItemView.m
@@ -13,7 +13,6 @@
 #import "NSView+ADBDrawingHelpers.h"
 
 @implementation BXCollectionItemView
-@synthesize delegate = _delegate;
 
 //Returns the original prototype we were copied from, to access properties that weren't copied.
 - (NSView *) prototype

--- a/Boxer/BXCoverArt.h
+++ b/Boxer/BXCoverArt.h
@@ -12,11 +12,9 @@
 /// an \c NSImage resource suitable for use as a file thumbnail, or draw the art directly into the
 /// current graphics context.
 @interface BXCoverArt : NSObject
-{
-	NSImage *sourceImage;
-}
+
 /// The original image we will render into cover art
-@property (strong) NSImage *sourceImage;
+@property (strong, nonatomic) NSImage *sourceImage;
 
 
 #pragma mark -

--- a/Boxer/BXCoverArt.m
+++ b/Boxer/BXCoverArt.m
@@ -12,8 +12,6 @@
 #import "ADBAppKitVersionHelpers.h"
 
 @implementation BXCoverArt
-@synthesize sourceImage;
-
 
 //We give gameboxes a fairly strong shadow to lift them out from light backgrounds
 + (NSShadow *) dropShadowForSize: (NSSize)iconSize

--- a/Boxer/BXCursorFadeAnimation.h
+++ b/Boxer/BXCursorFadeAnimation.h
@@ -10,10 +10,8 @@
 
 /// BXCursorFadeAnimation class description goes here.
 @interface BXCursorFadeAnimation : NSAnimation
-{
-	NSCursor *originalCursor;
-}
-@property (strong) NSCursor *originalCursor;
+
+@property (strong, nonatomic) NSCursor *originalCursor;
 
 - (NSCursor *) cursorWithOpacity: (CGFloat)opacity;
 

--- a/Boxer/BXCursorFadeAnimation.m
+++ b/Boxer/BXCursorFadeAnimation.m
@@ -11,7 +11,6 @@
 
 
 @implementation BXCursorFadeAnimation
-@synthesize originalCursor;
 
 - (void) setCurrentProgress: (NSAnimationProgress)progress
 {

--- a/Boxer/BXDrive+BXDriveArchiving.m
+++ b/Boxer/BXDrive+BXDriveArchiving.m
@@ -173,18 +173,18 @@
     
     //For other paths and strings, only bother recording them if they have been
     //manually changed from their autodetected versions.
-    if (self.mountPointURL && !_hasAutodetectedMountPoint)
+    if (self.mountPointURL && !self.hasAutodetectedMountPoint)
     {
         NSData *mountPointURLBookmark = BOOKMARK_FROM_URL(self.mountPointURL);
         [aCoder encodeObject: mountPointURLBookmark forKey: @"mountPointURLBookmark"];
     }
     
-    if (self.title && !_hasAutodetectedTitle)
+    if (self.title && !self.hasAutodetectedTitle)
     {
         [aCoder encodeObject: self.title forKey: @"title"];
     }
     
-    if (self.volumeLabel && !_hasAutodetectedVolumeLabel)
+    if (self.volumeLabel && !self.hasAutodetectedVolumeLabel)
         [aCoder encodeObject: self.volumeLabel forKey: @"volumeLabel"];
     
     if (self.filesystem.representedURLs.count)

--- a/Boxer/BXDrive.h
+++ b/Boxer/BXDrive.h
@@ -32,33 +32,6 @@ typedef NS_ENUM(NSInteger, BXDriveType) {
 /// \c BXDrive represents a single DOS drive and encapsulates all the data needed to mount the drive
 /// and locate it on the OS X filesystem. BXDrives are mounted via ADBFilesystem's mountDrive: method.
 @interface BXDrive : NSObject
-{
-    NSURL *_sourceURL;
-    NSURL *_shadowURL;
-    NSURL *_mountPointURL;
-    NSMutableSet *_equivalentURLs;
-    
-	NSString *_letter;
-	NSString *_title;
-	NSString *_volumeLabel;
-    NSString *_DOSVolumeLabel;
-	BXDriveType _type;
-	NSInteger _freeSpace;
-	BOOL _usesCDAudio;
-	BOOL _readOnly;
-	BOOL _locked;
-	BOOL _hidden;
-    BOOL _mounted;
-    
-    BOOL _hasAutodetectedMountPoint;
-    BOOL _hasAutodetectedLetter;
-    BOOL _hasAutodetectedTitle;
-    BOOL _hasAutodetectedVolumeLabel;
-    BOOL _hasAutodetectedType;
-    
-    id <ADBFilesystemPathAccess, ADBFilesystemLogicalURLAccess> _filesystem;
-}
-
 
 #pragma mark - Properties
 
@@ -106,29 +79,30 @@ typedef NS_ENUM(NSInteger, BXDriveType) {
 /// BXDefaultFreeSpace: which is ~250MB for hard disks, 1.44MB for floppies and 0B for CDROMs.
 /// Note that this is not an enforced limit: it only affects how much free space is reported
 /// to DOS programs.
-@property (assign, nonatomic) NSInteger freeSpace;
+@property (nonatomic) NSInteger freeSpace;
 
 /// Whether to use SDL CD-ROM audio: only relevant for folders mounted as CD-ROM drives.
 /// If YES, DOS emulation will read CD audio for this drive from the first audio CD volume mounted in OS X.
-@property (assign, nonatomic) BOOL usesCDAudio;
+@property (nonatomic) BOOL usesCDAudio;
 
 /// Whether to prevent DOS from writing to the OS X filesystem representing this drive. Defaults to NO.
 /// This property is ignored for CD-ROM drives and DOSBox's internal Z drive,
 /// which are always treated as read-only.
-@property (assign, nonatomic, getter=isReadOnly) BOOL readOnly;
+@property (nonatomic, getter=isReadOnly) BOOL readOnly;
 
 /// Whether to protect this drive from being unmounted from Boxer's drive manager UI. Defaults to NO.
 /// Ignored for DOSBox's internal Z drive, which is always locked.
-@property (assign, nonatomic, getter=isLocked) BOOL locked;
+@property (nonatomic, getter=isLocked) BOOL locked;
 
 /// Whether to hide this drive from Boxer's drive manager UI. Defaults to NO.
 /// Ignored for DOSBox's internal Z drive, which is always hidden.
-@property (assign, nonatomic, getter=isHidden) BOOL hidden;
+@property (nonatomic, getter=isHidden) BOOL hidden;
 
 /// Whether this drive is currently mounted in an emulation session.
 /// This is merely a flag to make displaying the state of a drive easier; setting it to YES
 /// will not actually mount the drive, just indicate that it is mounted somewhere.
-@property (assign, nonatomic, getter=isMounted) BOOL mounted;
+@property (nonatomic, getter=isMounted) BOOL mounted;
+
 
 
 #pragma mark - Immutable properties
@@ -148,7 +122,7 @@ typedef NS_ENUM(NSInteger, BXDriveType) {
 @property (readonly, strong, nonatomic) id <ADBFilesystemPathAccess, ADBFilesystemLogicalURLAccess> filesystem;
 
 /// A localized human-readable title for the drive's type, for display in the UI.
-@property (copy, readonly, nonatomic) NSString *localizedTypeDescription;
+@property (readonly, nonatomic) NSString *localizedTypeDescription;
 
 
 #pragma mark - Class methods

--- a/Boxer/BXDrive.m
+++ b/Boxer/BXDrive.m
@@ -19,22 +19,6 @@
 #pragma mark - Implementation
 
 @implementation BXDrive
-@synthesize sourceURL = _sourceURL;
-@synthesize shadowURL = _shadowURL;
-@synthesize mountPointURL = _mountPointURL;
-@synthesize letter = _letter;
-@synthesize title = _title;
-@synthesize volumeLabel = _volumeLabel;
-@synthesize DOSVolumeLabel = _DOSVolumeLabel;
-@synthesize type = _type;
-@synthesize freeSpace = _freeSpace;
-@synthesize usesCDAudio = _usesCDAudio;
-@synthesize readOnly = _readOnly;
-@synthesize locked = _locked;
-@synthesize hidden = _hidden;
-@synthesize mounted = _mounted;
-@synthesize filesystem = _filesystem;
-
 
 #pragma mark - Helper class methods
 
@@ -218,7 +202,7 @@
 		if (driveType == BXDriveAutodetect)
         {
             self.type = [self.class preferredTypeForContentsOfURL: sourceURL];
-            _hasAutodetectedType = YES;
+            self.hasAutodetectedType = YES;
 		}
 		else
         {
@@ -258,26 +242,26 @@
 			if (!self.mountPointURL)
             {
 				self.mountPointURL = [self.class mountPointForContentsOfURL: _sourceURL];
-                _hasAutodetectedMountPoint = YES;
+                self.hasAutodetectedMountPoint = YES;
             }
 			
 			//Automatically parse the drive letter, title and volume label from the name of the drive
 			if (!self.letter)
             {
                 self.letter = [self.class preferredDriveLetterForContentsOfURL: _sourceURL];
-                _hasAutodetectedLetter = YES;
+                self.hasAutodetectedLetter = YES;
             }
             
 			if (!self.volumeLabel)
             {
                 self.volumeLabel = [self.class preferredVolumeLabelForContentsOfURL: _sourceURL];
-                _hasAutodetectedVolumeLabel = YES;
+                self.hasAutodetectedVolumeLabel = YES;
             }
             
 			if (!self.title)
             {
                 self.title = [self.class preferredTitleForContentsOfURL: _sourceURL];
-                _hasAutodetectedTitle = YES;
+                self.hasAutodetectedTitle = YES;
             }
 		}
 	}
@@ -290,7 +274,7 @@
 	{
 		_mountPointURL = [mountPointURL copy];
 		
-        _hasAutodetectedMountPoint = NO;
+        self.hasAutodetectedMountPoint = NO;
         
         //Clear our old filesystem whenever the source changes: it will be recreated when needed.
         self.filesystem = nil;
@@ -305,7 +289,7 @@
 		_shadowURL = [shadowURL copy];
         
         //Clear our old filesystem, if it was shadowed: it will be recreated when needed.
-        if (_shadowURL && [_filesystem isKindOfClass: [ADBShadowedFilesystem class]])
+        if (_shadowURL && [self.filesystem isKindOfClass: [ADBShadowedFilesystem class]])
         {
             self.filesystem = nil;
         }
@@ -321,7 +305,7 @@
 	{
 		_letter = [driveLetter copy];
         
-        _hasAutodetectedLetter = NO;
+        self.hasAutodetectedLetter = NO;
 	}
 }
 
@@ -331,7 +315,7 @@
 	{
 		_volumeLabel = [newLabel copy];
 		
-        _hasAutodetectedVolumeLabel = NO;
+        self.hasAutodetectedVolumeLabel = NO;
 	}
 }
 
@@ -341,7 +325,7 @@
 	{
 		_title = [title copy];
 		
-        _hasAutodetectedTitle = NO;
+        self.hasAutodetectedTitle = NO;
 	}
 }
 

--- a/Boxer/BXDriveBundleImport.h
+++ b/Boxer/BXDriveBundleImport.h
@@ -20,13 +20,6 @@ NS_ERROR_ENUM(BXDriveBundleErrorDomain) {
 /// BXDriveBundleImport wraps BIN/CUE images and any associated audio tracks into a .cdmedia bundle,
 /// rewriting cue paths as necessary.
 @interface BXDriveBundleImport : ADBFileTransferSet <BXDriveImport>
-{
-	BXDrive *_drive;
-	NSURL *_destinationFolderURL;
-    NSURL *_destinationURL;
-    BOOL _hasWrittenFiles;
-}
-
 @end
 
 

--- a/Boxer/BXDriveBundleImport.m
+++ b/Boxer/BXDriveBundleImport.m
@@ -16,9 +16,12 @@
 
 NSString * const BXDriveBundleErrorDomain = @"BXDriveBundleErrorDomain";
 
-
+@interface BXDriveBundleImport ()
+@property (atomic) BOOL hasWrittenFiles;
+@end
 
 @implementation BXDriveBundleImport
+
 @synthesize drive = _drive;
 @synthesize destinationFolderURL = _destinationFolderURL;
 @synthesize destinationURL = _destinationURL;
@@ -146,9 +149,9 @@ NSString * const BXDriveBundleErrorDomain = @"BXDriveBundleErrorDomain";
     if (self.isCancelled) return;
     
     //Perform the standard file import from here on in.
-    _hasWrittenFiles = NO;
+    self.hasWrittenFiles = NO;
     [super main];
-    _hasWrittenFiles = YES;
+    self.hasWrittenFiles = YES;
     
     if (!self.error)
     {
@@ -196,7 +199,7 @@ NSString * const BXDriveBundleErrorDomain = @"BXDriveBundleErrorDomain";
 - (BOOL) undoTransfer
 {
 	BOOL undid = [super undoTransfer];
-	if (self.copyFiles && self.destinationURL && _hasWrittenFiles)
+	if (self.copyFiles && self.destinationURL && self.hasWrittenFiles)
 	{
 		undid = [[NSFileManager defaultManager] removeItemAtURL: self.destinationURL error: NULL];
 	}

--- a/Boxer/BXDrivePrivate.h
+++ b/Boxer/BXDrivePrivate.h
@@ -11,7 +11,13 @@
 
 @interface BXDrive ()
 
-@property (readwrite, assign, nonatomic) BXDriveType type;
+@property (readwrite, nonatomic) BXDriveType type;
 @property (readwrite, strong, nonatomic) id <ADBFilesystemPathAccess, ADBFilesystemLogicalURLAccess> filesystem;
+
+@property (nonatomic) BOOL hasAutodetectedMountPoint;
+@property (nonatomic) BOOL hasAutodetectedLetter;
+@property (nonatomic) BOOL hasAutodetectedType;
+@property (nonatomic) BOOL hasAutodetectedTitle;
+@property (nonatomic) BOOL hasAutodetectedVolumeLabel;
 
 @end

--- a/Boxer/BXEmulatedKeyboard.h
+++ b/Boxer/BXEmulatedKeyboard.h
@@ -28,45 +28,30 @@ typedef KBD_KEYS BXDOSKeyCode;
 /// \c BXEmulatedKeyboard represents the DOS PC's keyboard hardware, and offers an API for sending
 /// emulated key events and setting keyboard layout.
 @interface BXEmulatedKeyboard : NSObject
-{
-	BOOL _capsLockEnabled;
-	BOOL _numLockEnabled;
-    BOOL _scrollLockEnabled;
-    NSUInteger _pressedKeys[KBD_LAST];
-    
-    /// Whether to re-enable capslock and the active layout
-    /// once a simulated typing session is finished.
-    BOOL _enableActiveLayoutAfterTyping;
-    BOOL _enableCapslockAfterTyping;
-    
-	NSString *_preferredLayout;
-    
-    __unsafe_unretained NSTimer *_pendingKeypresses;
-}
 
 /// NOTE: these are only readwrite for the sake of BXCoalface.
 /// They should not be modified by code outside BXEmulator.
-@property (assign) BOOL capsLockEnabled;
-@property (assign) BOOL numLockEnabled;
-@property (assign) BOOL scrollLockEnabled;
+@property (nonatomic) BOOL capsLockEnabled;
+@property (nonatomic) BOOL numLockEnabled;
+@property (nonatomic) BOOL scrollLockEnabled;
 
 /// The DOS keyboard layout that is currently in use.
 @property (copy, nonatomic) NSString *activeLayout;
 
 /// Whether to map keyboard input through the active keyboard layout.
 /// If NO, input will be mapped according to a standard US keyboard layout instead.
-@property (assign, nonatomic) BOOL usesActiveLayout;
+@property (nonatomic) BOOL usesActiveLayout;
 
 /// The DOS keyboard layout that will be applied once emulation has started up.
 /// Set whenever activeLayout is changed.
-@property (copy) NSString *preferredLayout;
+@property (copy, nonatomic) NSString *preferredLayout;
 
 /// Returns \c YES if the emulated keyboard buffer is full, meaning further key events will be ignored.
-@property (readonly) BOOL keyboardBufferFull;
+@property (readonly, nonatomic) BOOL keyboardBufferFull;
 
 /// Whether we are currently typing text into the keyboard. Will be \c YES while the input from
 /// \c typeCharacters: is being processed.
-@property (readonly) BOOL isTyping;
+@property (readonly, nonatomic) BOOL isTyping;
 
 
 #pragma mark -

--- a/Boxer/BXEmulatedKeyboard.mm
+++ b/Boxer/BXEmulatedKeyboard.mm
@@ -25,7 +25,7 @@ const char* DOS_GetLoadedLayout(void);
 @interface BXEmulatedKeyboard ()
 
 //Assign rather than retain, because NSTimers retain their targets
-@property (assign) NSTimer *pendingKeypresses;
+@property (weak) NSTimer *pendingKeypresses;
 
 //Returns the DOS keycode constant that will produce the specified character
 //under the US keyboard layout, along with any modifiers needed to trigger it.
@@ -40,11 +40,14 @@ const char* DOS_GetLoadedLayout(void);
 #pragma mark Implementation
 
 @implementation BXEmulatedKeyboard
-@synthesize capsLockEnabled = _capsLockEnabled;
-@synthesize numLockEnabled = _numLockEnabled;
-@synthesize scrollLockEnabled = _scrollLockEnabled;
-@synthesize preferredLayout = _preferredLayout;
-@synthesize pendingKeypresses = _pendingKeypresses;
+{
+	NSUInteger _pressedKeys[KBD_LAST];
+	
+	//Whether to re-enable capslock and the active layout
+	//once a simulated typing session is finished.
+	BOOL _enableActiveLayoutAfterTyping;
+	BOOL _enableCapslockAfterTyping;
+}
 
 + (NSTimeInterval) defaultKeypressDuration { return 0.25; }
 

--- a/Boxer/BXEmulatedMT32.h
+++ b/Boxer/BXEmulatedMT32.h
@@ -86,26 +86,10 @@ typedef NS_OPTIONS(NSUInteger, BXMT32ROMType) {
 /// Unlike the other \c BXMIDIDevice classes, this currently feeds audio output back into
 /// DOSBox's own mixer.
 @interface BXEmulatedMT32 : NSObject <BXMIDIDevice, BXAudioSource>
-{
-    __unsafe_unretained id <BXEmulatedMT32Delegate> _delegate;
-    NSURL *_PCMROMURL;
-    NSURL *_controlROMURL;
-    NSError *_synthError;
-    unsigned int _sampleRate;
-    
-#ifdef __cplusplus
-    MT32Emu::Synth *_synth;
-    BXEmulatedMT32ReportHandler *_reportHandler;
-    MT32Emu::FileStream *_PCMROMHandle;
-    MT32Emu::FileStream *_controlROMHandle;
-    const MT32Emu::ROMImage *_PCMROMImage;
-    const MT32Emu::ROMImage *_controlROMImage;
-#endif
-}
 
 @property (copy, nonatomic) NSURL *PCMROMURL;
 @property (copy, nonatomic) NSURL *controlROMURL;
-@property (assign, nonatomic) id <BXEmulatedMT32Delegate> delegate;
+@property (weak, nonatomic) id <BXEmulatedMT32Delegate> delegate;
 @property (assign, nonatomic) unsigned int sampleRate;
 
 - (id <BXMIDIDevice>) initWithPCMROM: (NSURL *)PCMROMURL

--- a/Boxer/BXEmulatedMT32.mm
+++ b/Boxer/BXEmulatedMT32.mm
@@ -41,14 +41,12 @@ NSString * const BXMT32PCMROMTypeKey = @"BXMT32PCMROMType";
 
 @implementation BXEmulatedMT32
 {
-#ifdef __cplusplus
 	MT32Emu::Synth *_synth;
 	BXEmulatedMT32ReportHandler *_reportHandler;
 	MT32Emu::FileStream *_PCMROMHandle;
 	MT32Emu::FileStream *_controlROMHandle;
 	const MT32Emu::ROMImage *_PCMROMImage;
 	const MT32Emu::ROMImage *_controlROMImage;
-#endif
 }
 
 #pragma mark - ROM validation methods

--- a/Boxer/BXEmulatedMT32.mm
+++ b/Boxer/BXEmulatedMT32.mm
@@ -40,12 +40,16 @@ NSString * const BXMT32PCMROMTypeKey = @"BXMT32PCMROMType";
 #pragma mark Implementation
 
 @implementation BXEmulatedMT32
-@synthesize delegate = _delegate;
-@synthesize PCMROMURL = _PCMROMURL;
-@synthesize controlROMURL = _controlROMURL;
-@synthesize synthError = _synthError;
-@synthesize sampleRate = _sampleRate;
-
+{
+#ifdef __cplusplus
+	MT32Emu::Synth *_synth;
+	BXEmulatedMT32ReportHandler *_reportHandler;
+	MT32Emu::FileStream *_PCMROMHandle;
+	MT32Emu::FileStream *_controlROMHandle;
+	const MT32Emu::ROMImage *_PCMROMImage;
+	const MT32Emu::ROMImage *_controlROMImage;
+#endif
+}
 
 #pragma mark - ROM validation methods
 

--- a/Boxer/BXEmulatedMouse.h
+++ b/Boxer/BXEmulatedMouse.h
@@ -22,14 +22,6 @@
 /// \c BXEmulatedMouse represents the DOS PC's mouse and its driver, and offers an API for sending
 /// emulated mouse signals.
 @interface BXEmulatedMouse: NSObject
-{
-	BOOL _active;
-	NSPoint _position;
-	
-	BXMouseButtonMask _pressedButtons;
-    NSTimeInterval _lastButtonDown[BXMouseButtonMax];
-}
-
 
 #pragma mark -
 #pragma mark Properties

--- a/Boxer/BXEmulatedMouse.mm
+++ b/Boxer/BXEmulatedMouse.mm
@@ -29,9 +29,9 @@
 #pragma mark Implementation
 
 @implementation BXEmulatedMouse
-@synthesize active = _active;
-@synthesize position = _position;
-@synthesize pressedButtons = _pressedButtons;
+{
+	NSTimeInterval _lastButtonDown[BXMouseButtonMax];
+}
 
 - (id) init
 {

--- a/Boxer/BXEmulatorConfiguration.h
+++ b/Boxer/BXEmulatorConfiguration.h
@@ -11,13 +11,6 @@
 /// \c BXEmulatorConfiguration is a Property List-style parser for configuration files in DOSBox format.
 /// It can read and write conf files, though it is not currently able to preserve layout and comments.
 @interface BXEmulatorConfiguration : NSObject
-{
-	//Our private storage of configuration sections
-	NSMutableDictionary *_sections;
-	
-	NSString *_preamble;
-	NSString *_startupCommandsPreamble;
-}
 
 #pragma mark -
 #pragma mark Properties
@@ -26,10 +19,10 @@
 @property (readonly, nonatomic) BOOL isEmpty;
 
 /// Returns a dictionary of all settings organised by section (not including startup commands.)
-@property (copy, readonly, nonatomic) NSDictionary *settings;
+@property (readonly, nonatomic) NSDictionary *settings;
 
 /// Returns an array of all startup commands.
-@property (copy, readonly, nonatomic) NSArray<NSString*> *startupCommands;
+@property (readonly, nonatomic) NSArray<NSString*> *startupCommands;
 
 /// A string to prepend as a header comment at the start of the configuration file.
 /// Used by description and writeToFile:error:

--- a/Boxer/BXEmulatorErrors.mm
+++ b/Boxer/BXEmulatorErrors.mm
@@ -297,8 +297,6 @@ NSString * const BXEmulatorUnrecoverableException = @"BXEmulatorUnrecoverableExc
 
 
 @implementation BXEmulatorException
-@synthesize callStackReturnAddresses = _BXCallStackReturnAddresses;
-@synthesize callStackSymbols = _BXCallStackSymbols;
 
 + (id) exceptionWithName: (NSString *)name
        originalException: (boxer_emulatorException *)cppException

--- a/Boxer/BXEmulatorPrivate.h
+++ b/Boxer/BXEmulatorPrivate.h
@@ -697,10 +697,6 @@ struct boxer_emulatorException: public std::exception {
 
 
 @interface BXEmulatorException: NSException
-{
-    NSArray *_BXCallStackReturnAddresses;
-    NSArray *_BXCallStackSymbols;
-}
 
 @property (copy) NSArray *callStackReturnAddresses;
 @property (copy) NSArray *callStackSymbols;

--- a/Boxer/BXExternalMIDIDevice.h
+++ b/Boxer/BXExternalMIDIDevice.h
@@ -22,19 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 #define BXVolumeSyncDelay 0.05
 
 @interface BXExternalMIDIDevice : NSObject <BXMIDIDevice>
-{
-	MIDIPortRef _port;
-	MIDIClientRef _client;
-	MIDIEndpointRef _destination;
-    
-    NSTimeInterval _secondsPerByte;
-    
-    NSDate *_dateWhenReady;
-    
-    float _volume;
-    float _requestedVolume;
-    NSTimer *_volumeSyncTimer;
-}
 
 /// The destination this device is connecting to. Set at initialization time.
 @property (readonly, nonatomic) MIDIEndpointRef destination;
@@ -48,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The master volume set by the MIDI-using application via sysex, from 0.0 to 1.0.
 /// This will be multiplied by @volume to arrive at the actual volume passed on the device.
 @property (assign, nonatomic) float requestedVolume;
+
+@property (assign, nonatomic) NSTimeInterval secondsPerByte;
 
 
 #pragma mark -

--- a/Boxer/BXExternalMIDIDevice.m
+++ b/Boxer/BXExternalMIDIDevice.m
@@ -33,10 +33,12 @@
 #pragma mark Implementation
 
 @implementation BXExternalMIDIDevice
-@synthesize dateWhenReady = _dateWhenReady;
-@synthesize destination = _destination;
-@synthesize volume = _volume;
-@synthesize requestedVolume = _requestedVolume;
+{
+	MIDIPortRef _port;
+	MIDIClientRef _client;
+	
+	NSTimer *_volumeSyncTimer;
+}
 
 #pragma mark -
 #pragma mark Class helper methods

--- a/Boxer/BXExternalMT32.m
+++ b/Boxer/BXExternalMT32.m
@@ -20,7 +20,7 @@
 - (NSTimeInterval) processingDelayForSysex: (NSData *)sysex
 {
     //The calculations for these sysex processing delays have been adapted from DOSBox's delaysysex patch.
-    NSTimeInterval baseDelay = (BXExternalMT32DelayFactor * _secondsPerByte * sysex.length) + BXExternalMT32BaseDelay;
+    NSTimeInterval baseDelay = (BXExternalMT32DelayFactor * self.secondsPerByte * sysex.length) + BXExternalMT32BaseDelay;
     
     //If this wasn't a valid MT-32 sysex message, ignore it and go with the standard delay.
     //(Even if the MT-32 can't handle it, it'll still take time for it to reach the MT-32 and get rejected.)

--- a/Boxer/BXFilterGallery.h
+++ b/Boxer/BXFilterGallery.h
@@ -15,21 +15,20 @@
 @end
 
 @interface BXFilterPortrait : NSButton
-{
-	CGFloat _illumination;
-}
+
 /// The current illumination, which controls the brightness of the portrait and the opacity of the
 /// spotlight. This is animatable via -animator and will change automatically when the button's state
 /// is toggled on or off.
-@property (assign, nonatomic) CGFloat illumination;
+@property (nonatomic) CGFloat illumination;
+
 @end
 
 @interface BXFilterPortraitCell : NSButtonCell
 
 /// Methods defining how the button title text should be rendered
-@property (readonly, weak) NSColor *titleColor;
-@property (readonly, weak) NSShadow *titleShadow;
-@property (readonly, weak) NSDictionary *titleAttributes;
+@property (readonly, nonatomic) NSColor *titleColor;
+@property (readonly, nonatomic) NSShadow *titleShadow;
+@property (readonly, nonatomic) NSDictionary *titleAttributes;
 
 - (void) drawSpotlightWithFrame: (NSRect)frame inView: (NSView *)controlView withAlpha: (CGFloat)alpha;
 

--- a/Boxer/BXFilterGallery.m
+++ b/Boxer/BXFilterGallery.m
@@ -51,7 +51,6 @@
 @end
 
 @implementation BXFilterPortrait
-@synthesize illumination = _illumination;
 
 + (id)defaultAnimationForKey: (NSString *)key
 {

--- a/Boxer/BXGameProfile.h
+++ b/Boxer/BXGameProfile.h
@@ -31,29 +31,6 @@ extern NSString * const BXGenericProfileIdentifier;
 /// It has helper class methods for detecting a game profile from a filesystem path, and for
 /// determining the 'era' of a particular game at a filesystem path.
 @interface BXGameProfile : NSObject
-{
-    NSString *_identifier;
-    NSUInteger _priority;
-	NSString *_gameName;
-	NSString *_profileDescription;
-	NSArray *_configurations;
-    
-    NSDictionary *_driveLabelMappings;
-    NSString *_preferredInstallationFolderPath;
-	NSArray *_installerPatterns;
-    NSArray *_ignoredInstallerPatterns;
-	
-	BXReleaseMedium _coverArtMedium;
-	BXDriveType _sourceDriveType;
-	NSInteger _requiredDiskSpace;
-	BOOL _shouldMountHelperDrivesDuringImport;
-    BOOL _shouldMountTempDrive;
-    BOOL _requiresCDROM;
-    
-    BOOL _shouldImportMountCommands;
-    BOOL _shouldImportLaunchCommands;
-    BOOL _shouldImportSettings;
-}
 
 #pragma mark -
 #pragma mark Properties

--- a/Boxer/BXGameProfile.m
+++ b/Boxer/BXGameProfile.m
@@ -53,26 +53,6 @@ NSString * const BXInvalidGameDateThreshold = @"1981-01-01 00:00:00 +0000";
 
 
 @implementation BXGameProfile
-@synthesize priority = _priority;
-@synthesize gameName = _gameName;
-@synthesize configurations = _configurations;
-@synthesize identifier = _identifier;
-@synthesize profileDescription = _profileDescription;
-@synthesize sourceDriveType = _sourceDriveType;
-@synthesize releaseMedium = _coverArtMedium;
-@synthesize requiredDiskSpace = _requiredDiskSpace;
-@synthesize shouldMountHelperDrivesDuringImport = _shouldMountHelperDrivesDuringImport;
-@synthesize shouldMountTempDrive = _shouldMountTempDrive;
-@synthesize requiresCDROM = _requiresCDROM;
-
-@synthesize installerPatterns = _installerPatterns;
-@synthesize ignoredInstallerPatterns = _ignoredInstallerPatterns;
-@synthesize driveLabelMappings = _driveLabelMappings;
-
-@synthesize shouldImportMountCommands = _shouldImportMountCommands;
-@synthesize shouldImportLaunchCommands = _shouldImportLaunchCommands;
-@synthesize shouldImportSettings = _shouldImportSettings;
-@synthesize preferredInstallationFolderPath = _preferredInstallationFolderPath;
 
 + (BXReleaseMedium) mediumOfGameAtURL: (NSURL *)baseURL
 {

--- a/Boxer/BXGamebox.h
+++ b/Boxer/BXGamebox.h
@@ -117,43 +117,36 @@ typedef NS_ENUM(NSUInteger, BXGameIdentifierType) {
 /// TODO: it is inappropriate to subclass NSBundle for representing a modifiable file package,
 /// and we should instead be using an NSFileWrapper directory wrapper.
 @interface BXGamebox : NSBundle <ADBUndoable>
-{
-	NSMutableDictionary *_gameInfo;
-    NSMutableArray *_launchers;
-    __weak id <ADBUndoDelegate> _undoDelegate;
-    BOOL _lastWritableStatus;
-    CFAbsoluteTime _nextWriteableCheckTime;
-}
 
 #pragma mark - Properties
 
 /// Returns a dictionary of gamebox metadata loaded from Boxer.plist.
 /// Keys in this dictionary also be retrieved with gameInfoForKey:, and set with setGameInfo:forKey:.
-@property (readonly, strong, nonatomic, nullable) NSDictionary<NSString*,id> *gameInfo;
+@property (readonly, strong, nonatomic, null_resettable) NSDictionary<NSString*,id> *gameInfo;
 
 /// The name of the game, suitable for display. This is the gamebox's filename minus any ".boxer" extension.
-@property (copy, readonly, nonatomic) NSString *gameName;
+@property (readonly, nonatomic) NSString *gameName;
 
 /// The unique identifier of this game.
 @property (copy, nonatomic) NSString *gameIdentifier;
 
 /// URLs to bundled drives and images of the specified types.
-@property (copy, readonly, nonatomic) NSArray<NSURL*> *hddVolumeURLs;
-@property (copy, readonly, nonatomic) NSArray<NSURL*> *cdVolumeURLs;
-@property (copy, readonly, nonatomic) NSArray<NSURL*> *floppyVolumeURLs;
+@property (readonly, nonatomic) NSArray<NSURL*> *hddVolumeURLs;
+@property (readonly, nonatomic) NSArray<NSURL*> *cdVolumeURLs;
+@property (readonly, nonatomic) NSArray<NSURL*> *floppyVolumeURLs;
 
 /// An array of drives bundled inside this gamebox, ordered by drive letter and filename.
-@property (copy, readonly, nonatomic) NSArray<BXDrive *> *bundledDrives;
+@property (readonly, nonatomic) NSArray<BXDrive *> *bundledDrives;
 
 /// Returns the URL at which the configuration file is stored (which may not yet exist.)
-@property (copy, readonly, nonatomic) NSURL *configurationFileURL;
+@property (readonly, nonatomic) NSURL *configurationFileURL;
 
 /// Returns the URL of the target program saved under Boxer 1.3.x and below.
-@property (copy, readonly, nonatomic) NSURL *legacyTargetURL;
+@property (readonly, nonatomic) NSURL *legacyTargetURL;
 
 /// Whether the emulation should finish once the default launcher exits,
 /// rather than returning to the DOS prompt. No longer supported.
-@property (assign, nonatomic) BOOL closeOnExit;
+@property (nonatomic) BOOL closeOnExit;
 
 /// The cover art image for this gamebox. Will be nil if the gamebox has no custom cover art.
 /// This is stored internally as the gamebox's OS X icon resource.
@@ -164,14 +157,14 @@ typedef NS_ENUM(NSUInteger, BXGameIdentifierType) {
 
 /// The default launcher for this gamebox, which should be launched the first time the gamebox is run.
 /// This will be @c nil if the gamebox has no default launcher.
-@property (copy, readonly, nonatomic, nullable) NSDictionary<NSString*,id> *defaultLauncher;
+@property (readonly, nonatomic, nullable) NSDictionary<NSString*,id> *defaultLauncher;
 
 /// The index in the launchers array of the default launcher.
 /// Will be NSNotFound if no default launcher has been set.
-@property (assign, nonatomic) NSUInteger defaultLauncherIndex;
+@property (nonatomic) NSUInteger defaultLauncherIndex;
 
 /// The delegate from whom we will request an undo manager for undoable operations.
-@property (weak, nullable) id <ADBUndoDelegate> undoDelegate;
+@property (weak, nonatomic) id <ADBUndoDelegate> undoDelegate;
 
 
 #pragma mark - Instance methods

--- a/Boxer/BXGamebox.m
+++ b/Boxer/BXGamebox.m
@@ -84,8 +84,11 @@ NSString * const BXGameboxErrorDomain = @"BXGameboxErrorDomain";
 
 
 @implementation BXGamebox
-@synthesize gameInfo = _gameInfo;
-@synthesize undoDelegate = _undoDelegate;
+{
+	NSMutableArray *_launchers;
+	BOOL _lastWritableStatus;
+	CFAbsoluteTime _nextWriteableCheckTime;
+}
 
 //We ignore files with these names when considering which programs are important enough to list
 //TODO: read this data from a configuration plist instead

--- a/Boxer/BXGamesFolderPanelController.h
+++ b/Boxer/BXGamesFolderPanelController.h
@@ -11,10 +11,6 @@
 /// BXGamesFolderPanelController displays the choose-a-game-folder open panel, and manages its
 /// accessory view. It is also responsible for adding sample games to the chosen folder, if requested.
 @interface BXGamesFolderPanelController : NSViewController <NSOpenSavePanelDelegate>
-{
-	NSButton *_sampleGamesToggle;
-	NSButton *_useShelfAppearanceToggle;
-}
 
 @property (strong, nonatomic) IBOutlet NSButton *sampleGamesToggle;
 @property (strong, nonatomic) IBOutlet NSButton *useShelfAppearanceToggle;

--- a/Boxer/BXGamesFolderPanelController.m
+++ b/Boxer/BXGamesFolderPanelController.m
@@ -19,8 +19,6 @@
 @end
 
 @implementation BXGamesFolderPanelController
-@synthesize sampleGamesToggle = _sampleGamesToggle;
-@synthesize useShelfAppearanceToggle = _useShelfAppearanceToggle;
 
 + (id) controller
 {

--- a/Boxer/BXHIDControllerProfile.h
+++ b/Boxer/BXHIDControllerProfile.h
@@ -34,13 +34,6 @@ typedef NS_ENUM(NSInteger, BXControllerStyle) {
 /// \c BXControllerProfile is controller- and joystick-specific and each emulation session maintains
 /// its own set of active controller profiles.
 @interface BXHIDControllerProfile : NSObject
-{
-	DDHidJoystick *_device;
-	id <BXEmulatedJoystick> _emulatedJoystick;
-	BXEmulatedKeyboard *_emulatedKeyboard;
-	NSMutableDictionary *_bindings;
-    BXControllerStyle _controllerStyle;
-}
 
 /// The HID controller whose inputs we are converting from.
 @property (strong, nonatomic) DDHidJoystick *device;

--- a/Boxer/BXHIDControllerProfile.m
+++ b/Boxer/BXHIDControllerProfile.m
@@ -12,12 +12,6 @@
 
 @implementation BXHIDControllerProfile
 
-@synthesize device = _device;
-@synthesize emulatedJoystick = _emulatedJoystick;
-@synthesize emulatedKeyboard = _emulatedKeyboard;
-@synthesize bindings = _bindings;
-@synthesize controllerStyle = _controllerStyle;
-
 #pragma mark -
 #pragma mark Constants
 

--- a/Boxer/BXHIDInputBinding.h
+++ b/Boxer/BXHIDInputBinding.h
@@ -29,9 +29,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 @interface BXHIDButtonBinding : NSObject <BXHIDInputBinding>
-{
-    id <BXOutputBinding> _outputBinding;
-}
 
 /// This binding will be sent 1.0 when the joystick button is pressed, and 0.0 when released.
 @property (strong, nonatomic) id <BXOutputBinding> outputBinding;
@@ -42,14 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 @interface BXHIDAxisBinding : NSObject <BXHIDInputBinding>
-{
-    id <BXOutputBinding> _positiveBinding;
-    id <BXOutputBinding> _negativeBinding;
-    
-    BOOL _inverted;
-    float _deadzone;
-    BOOL _unidirectional;
-}
 
 /// This binding will be sent the absolute axis value when the axis is positive,
 /// and 0.0 when the axis is centered or negative.
@@ -77,10 +66,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 @interface BXHIDPOVSwitchBinding : NSObject <BXHIDInputBinding>
-{
-    NSMutableDictionary *_outputBindings;
-    ADBHIDPOVSwitchDirection _previousDirection;
-}
 
 /// Creates a new binding from interleaved pairs of bindings and directions, followed by a \c nil sentinel.
 + (instancetype) bindingWithOutputBindingsAndDirections: (id <BXOutputBinding>)binding, ... NS_REQUIRES_NIL_TERMINATION;

--- a/Boxer/BXHIDInputBinding.m
+++ b/Boxer/BXHIDInputBinding.m
@@ -14,7 +14,6 @@
 #define BXDefaultAxisDeadzone 0.20f
 
 @implementation BXHIDButtonBinding
-@synthesize outputBinding = _outputBinding;
 
 + (id) binding
 {
@@ -45,11 +44,6 @@
 
 
 @implementation BXHIDAxisBinding
-@synthesize positiveBinding = _positiveBinding;
-@synthesize negativeBinding = _negativeBinding;
-@synthesize deadzone = _deadzone;
-@synthesize inverted = _inverted;
-@synthesize unidirectional = _unidirectional;
 
 + (id) binding
 {
@@ -129,11 +123,13 @@
 
 
 @interface BXHIDPOVSwitchBinding ()
+
 @property (strong, nonatomic) NSMutableDictionary *outputBindings;
+@property (nonatomic) ADBHIDPOVSwitchDirection previousDirection;
+
 @end
 
 @implementation BXHIDPOVSwitchBinding
-@synthesize outputBindings = _outputBindings;
 
 + (id) binding
 {
@@ -174,7 +170,7 @@
     if (self)
     {
         self.outputBindings = [NSMutableDictionary dictionaryWithCapacity: 8];
-		_previousDirection = ADBHIDPOVCentered;
+		self.previousDirection = ADBHIDPOVCentered;
     }
     return self;
 }
@@ -222,9 +218,9 @@
 {
     ADBHIDPOVSwitchDirection direction = [ADBHIDEvent closest8WayDirectionForPOV: event.POVDirection];
     
-    if (direction != _previousDirection)
+    if (direction != self.previousDirection)
     {
-        NSSet *inactiveBindings = [self closestBindingsForDirection: _previousDirection];
+        NSSet *inactiveBindings = [self closestBindingsForDirection: self.previousDirection];
         NSSet *activeBindings = [self closestBindingsForDirection: direction];
         
         for (id <BXOutputBinding> binding in inactiveBindings)
@@ -239,7 +235,7 @@
                 [binding applyInputValue: kBXOutputBindingMax];
         }
         
-        _previousDirection = direction;
+        self.previousDirection = direction;
     }
 }
 

--- a/Boxer/BXHUDLevelIndicatorCell.h
+++ b/Boxer/BXHUDLevelIndicatorCell.h
@@ -10,10 +10,6 @@
 /// BXHUDLevelIndicatorCell is a shadowed white level indicator
 /// designed for bezel notifications.
 @interface BXHUDLevelIndicatorCell : NSLevelIndicatorCell
-{
-	NSColor *indicatorColor;
-	NSShadow *indicatorShadow;
-}
 
 @property (copy, nonatomic) NSColor *indicatorColor;
 @property (copy, nonatomic) NSShadow *indicatorShadow;

--- a/Boxer/BXHUDLevelIndicatorCell.m
+++ b/Boxer/BXHUDLevelIndicatorCell.m
@@ -11,7 +11,6 @@
 
 
 @implementation BXHUDLevelIndicatorCell
-@synthesize indicatorShadow, indicatorColor;
 
 + (CGFloat) heightForControlSize: (NSControlSize)size
 {

--- a/Boxer/BXHelpMenuController.h
+++ b/Boxer/BXHelpMenuController.h
@@ -15,15 +15,6 @@
 /// and links to look up the game on Mobygames or Replacementdocs.
 /// This controller is instantiated in MainMenu.xib.
 @interface BXHelpMenuController : NSObject
-{
-	NSMenuItem *_mobygamesItem;
-	NSMenuItem *_replacementDocsItem;
-    NSMenuItem *_helpLinksDivider;
-    NSMenuItem *_documentationDivider;
-    
-    BOOL _needsHelpLinksRefresh;
-    BOOL _needsSessionDocsRefresh;
-}
 @property (strong, nonatomic) IBOutlet NSMenuItem *mobygamesItem;
 @property (strong, nonatomic) IBOutlet NSMenuItem *replacementDocsItem;
 @property (strong, nonatomic) IBOutlet NSMenuItem *helpLinksDivider;

--- a/Boxer/BXHelpMenuController.m
+++ b/Boxer/BXHelpMenuController.m
@@ -28,10 +28,10 @@
 
 
 @implementation BXHelpMenuController
-@synthesize mobygamesItem = _mobygamesItem;
-@synthesize replacementDocsItem = _replacementDocsItem;
-@synthesize documentationDivider = _documentationDivider;
-@synthesize helpLinksDivider = _helpLinksDivider;
+{
+	BOOL _needsHelpLinksRefresh;
+	BOOL _needsSessionDocsRefresh;
+}
 
 - (void) awakeFromNib
 {

--- a/Boxer/BXImportDropzone.h
+++ b/Boxer/BXImportDropzone.h
@@ -15,10 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// the file's icon after dropping. Clicking the region will reveal a file picker.
 /// (\c BXImportDropzone does not actually handle drag-drop events itself: the panel itself does that.)
 @interface BXImportDropzone : NSButton
-{
-	CGFloat borderPhase;
-	CGFloat borderOutset;
-}
 
 //Whether we're the target of a drag-drop operation. When YES, the dropzone's border will animate.
 //We now use NSControl's highlighted property.

--- a/Boxer/BXImportDropzone.m
+++ b/Boxer/BXImportDropzone.m
@@ -27,7 +27,6 @@
 
 
 @implementation BXImportDropzone
-@synthesize borderPhase, borderOutset;
 
 #pragma mark -
 #pragma mark Helper class methods
@@ -162,13 +161,13 @@
 - (void) setBorderPhase: (CGFloat)phase
 {
 	//Wrap the phase to the length of our dash pattern
-	borderPhase = (CGFloat)((NSUInteger)phase % 18);
+	_borderPhase = (CGFloat)((NSUInteger)phase % 18);
 	[self setNeedsDisplay: YES];
 }
 
 - (void) setBorderOutset: (CGFloat)outset
 {
-	borderOutset = outset;
+	_borderOutset = outset;
 	[self setNeedsDisplay: YES];
 }
 
@@ -204,7 +203,7 @@
 		if (NSIntersectsRect(dirtyRect, borderFrame))
 		{
 			[borderColor set];
-			NSBezierPath *border = [[self class] borderForFrame: borderFrame withPhase: borderPhase];
+			NSBezierPath *border = [[self class] borderForFrame: borderFrame withPhase: self.borderPhase];
 			[border stroke];
 		}
 		

--- a/Boxer/BXImportDropzonePanelController.h
+++ b/Boxer/BXImportDropzonePanelController.h
@@ -15,22 +15,17 @@
 /// \c BXImportDropzonePanelController controls the behaviour of the dropzone panel
 /// in the game import process.
 @interface BXImportDropzonePanelController : NSViewController <NSOpenSavePanelDelegate>
-{
-    __unsafe_unretained BXImportWindowController *_controller;
-	BXImportDropzone *_dropzone;
-	BXBlueprintProgressIndicator *_spinner;
-}
 
-/// The dropzone within the dropzone panel
-@property (strong, nonatomic, nullable) IBOutlet BXImportDropzone *dropzone;
+/// The dropzone within the dropzone panel.
+@property (strong, nonatomic) IBOutlet BXImportDropzone *dropzone;
 
 /// The progress indicator shown when scanning a game for installers.
 /// (This now lives on a separate interstitial view and not the Dropzone
 /// view, but I can't be bothered making a second controller for it.)
-@property (strong, nonatomic, nullable) IBOutlet BXBlueprintProgressIndicator *spinner;
+@property (strong, nonatomic) IBOutlet BXBlueprintProgressIndicator *spinner;
 
-/// A reference to our window controller
-@property (assign, nonatomic, nullable) IBOutlet BXImportWindowController *controller;
+/// A back-reference to our owning window controller
+@property (unsafe_unretained, nonatomic) IBOutlet BXImportWindowController *controller;
 
 
 /// Display a file picker for choosing a folder or disc image to import

--- a/Boxer/BXImportDropzonePanelController.m
+++ b/Boxer/BXImportDropzonePanelController.m
@@ -14,18 +14,7 @@
 #import "BXAppController.h"
 
 
-#pragma mark -
-#pragma mark Private method declarations
-
-@interface BXImportDropzonePanelController ()
-
-@end
-
-
 @implementation BXImportDropzonePanelController
-@synthesize dropzone = _dropzone;
-@synthesize controller = _controller;
-@synthesize spinner = _spinner;
 
 #pragma mark -
 #pragma mark Initialization and deallocation

--- a/Boxer/BXImportFinalizingPanelController.h
+++ b/Boxer/BXImportFinalizingPanelController.h
@@ -13,22 +13,19 @@
 
 /// \c BXImportFinalizingPanelController manages the finalizing-gamebox view of the game import window.
 @interface BXImportFinalizingPanelController : NSViewController
-{
-    __unsafe_unretained BXImportWindowController *_controller;
-}
 
 #pragma mark -
 #pragma mark Properties
 
-/// A reference to our window controller.
-@property (assign, nonatomic) IBOutlet BXImportWindowController *controller;
+/// A back-reference to our owning window controller.
+@property (unsafe_unretained, nonatomic) IBOutlet BXImportWindowController *controller;
 
 /// A textual description of what import stage we are currently performing.
 /// Used for populating the description field beneath the progress bar.
-@property (copy, readonly, nonatomic) NSString *progressDescription;
+@property (readonly, nonatomic) NSString *progressDescription;
 
 /// The label and enabledness of the stop importing/skip importing button.
-@property (copy, readonly, nonatomic) NSString * cancelButtonLabel;
+@property (readonly, nonatomic) NSString * cancelButtonLabel;
 @property (readonly, nonatomic) BOOL cancelButtonEnabled;
 
 /// Whether to show the tip about importing additional CDs.

--- a/Boxer/BXImportFinalizingPanelController.m
+++ b/Boxer/BXImportFinalizingPanelController.m
@@ -28,7 +28,6 @@
 #pragma mark Implementation
 
 @implementation BXImportFinalizingPanelController
-@synthesize controller = _controller;
 
 #pragma mark -
 #pragma mark Cancel button behaviour

--- a/Boxer/BXImportFinishedPanelController.h
+++ b/Boxer/BXImportFinishedPanelController.h
@@ -14,14 +14,9 @@
 /// \c BXImportFinishedPanelController controls the appearance and behaviour of the final
 /// your-gamebox-is-finished panel of the import process.
 @interface BXImportFinishedPanelController : NSViewController
-{
-	__unsafe_unretained BXImportWindowController *_controller;
-	BXImportIconDropzone *_iconView;
-	NSTextField *_nameField;
-}
 
-/// A reference to our window controller.
-@property (assign, nonatomic) IBOutlet BXImportWindowController *controller;
+/// A back-reference to our owning window controller.
+@property (unsafe_unretained, nonatomic) IBOutlet BXImportWindowController *controller;
 
 /// The image well that displays the gamebox icon.
 @property (strong, nonatomic) IBOutlet BXImportIconDropzone *iconView;

--- a/Boxer/BXImportFinishedPanelController.m
+++ b/Boxer/BXImportFinishedPanelController.m
@@ -15,9 +15,6 @@
 #import "NSWorkspace+ADBFileTypes.h"
 
 @implementation BXImportFinishedPanelController
-@synthesize controller = _controller;
-@synthesize iconView = _iconView;
-@synthesize nameField = _nameField;
 
 + (NSSet *) keyPathsForValuesAffectingGameboxIcon
 {

--- a/Boxer/BXImportInstallerPanelController.h
+++ b/Boxer/BXImportInstallerPanelController.h
@@ -18,16 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// \c BXImportInstallerPanelController controls the behaviour of the choose-thine-installer panel
 /// in the game import process.
 @interface BXImportInstallerPanelController : NSViewController < NSOpenSavePanelDelegate >
-{
-    __unsafe_unretained BXImportWindowController *_controller;
-    NSPopUpButton *_installerSelector;
-}
 
-/// A reference to our window controller.
-@property (assign, nonatomic, nullable) IBOutlet BXImportWindowController *controller;
+/// A back-reference to our owning window controller.
+@property (unsafe_unretained, nonatomic) IBOutlet BXImportWindowController *controller;
 
 /// The drop-down selector we populate with our installer program options
-@property (strong, nonatomic, nullable) IBOutlet NSPopUpButton *installerSelector;
+@property (strong, nonatomic) IBOutlet NSPopUpButton *installerSelector;
 
 /// Whether we can show a menu option to let the user pick an installer from an open panel.
 /// Will be \c NO if the source URL of the import is a disk image, rather than a folder.

--- a/Boxer/BXImportInstallerPanelController.m
+++ b/Boxer/BXImportInstallerPanelController.m
@@ -37,8 +37,6 @@
 
 
 @implementation BXImportInstallerPanelController
-@synthesize installerSelector = _installerSelector;
-@synthesize controller = _controller;
 
 #pragma mark -
 #pragma mark Initialization and deallocation

--- a/Boxer/BXImportTipsPanelController.h
+++ b/Boxer/BXImportTipsPanelController.h
@@ -9,13 +9,9 @@
 
 
 @interface BXImportTipsPanelController : BXProgramPanelController
-{
-	IBOutlet NSView *finishImportingPanel;
-	IBOutlet NSView *installerTipsPanel;
-}
 
-@property (strong, nonatomic) NSView *finishImportingPanel;
-@property (strong, nonatomic) NSView *installerTipsPanel;
+@property (strong, nonatomic) IBOutlet NSView *finishImportingPanel;
+@property (strong, nonatomic) IBOutlet NSView *installerTipsPanel;
 
 /// Used by installerTipsPanel to show the help page for game installation.
 - (IBAction) showInstallerHelp: (id)sender;

--- a/Boxer/BXImportTipsPanelController.m
+++ b/Boxer/BXImportTipsPanelController.m
@@ -12,7 +12,6 @@
 
 
 @implementation BXImportTipsPanelController
-@synthesize finishImportingPanel, installerTipsPanel;
 
 - (NSString *) nibName	{ return @"ImportTipsPanel"; }
 
@@ -30,12 +29,12 @@
 	if ([[session emulator] isAtPrompt])
 	{
 		//Show the UI for finishing the import process once we return to the DOS prompt
-		panel = finishImportingPanel;
+		panel = self.finishImportingPanel;
 	}
 	else
 	{
 		//Show installer tips while any program is running
-		panel = installerTipsPanel;
+		panel = self.installerTipsPanel;
 	}
 	
 	[self setActivePanel: panel];

--- a/Boxer/BXImportWindowController.h
+++ b/Boxer/BXImportWindowController.h
@@ -14,33 +14,25 @@
 /// animation and transitions between the window's various views.
 /// It takes its marching orders from the BXImportSession document class.
 @interface BXImportWindowController : ADBMultiPanelWindowController
-{
-	IBOutlet NSView *dropzonePanel;
-	IBOutlet NSView *loadingPanel;
-	IBOutlet NSView *installerPanel;
-	IBOutlet NSView *finalizingPanel;
-	IBOutlet NSView *finishedPanel;
-}
-
 
 #pragma mark -
 #pragma mark Properties
 
 /// The dropzone panel, displayed initially when no import source has been selected 
-@property (strong, nonatomic) NSView *dropzonePanel;
+@property (strong, nonatomic) IBOutlet NSView *dropzonePanel;
 
 /// The indeterminate progress panel shown while scanning a game folder for installers.
-@property (strong, nonatomic) NSView *loadingPanel;
+@property (strong, nonatomic) IBOutlet NSView *loadingPanel;
 
 /// The choose-thine-installer panel, displayed if the chosen game source contains
 /// installers to choose from.
-@property (strong, nonatomic) NSView *installerPanel;
+@property (strong, nonatomic) IBOutlet NSView *installerPanel;
 
 /// The finalizing-gamebox panel, which shows the progress of the import operation.
-@property (strong, nonatomic) NSView *finalizingPanel;
+@property (strong, nonatomic) IBOutlet NSView *finalizingPanel;
 
 /// The final gamebox panel, which displays the finished gamebox for the user to launch.
-@property (strong, nonatomic) NSView *finishedPanel;
+@property (strong, nonatomic) IBOutlet NSView *finishedPanel;
 
 
 /// Recast NSWindowController's standard accessors so that we get our own classes

--- a/Boxer/BXImportWindowController.m
+++ b/Boxer/BXImportWindowController.m
@@ -13,7 +13,6 @@
 #import "ADBAppKitVersionHelpers.h"
 
 @implementation BXImportWindowController
-@synthesize dropzonePanel, loadingPanel, installerPanel, finalizingPanel, finishedPanel;
 
 - (BXImportSession *) document { return (BXImportSession *)[super document]; }
 

--- a/Boxer/BXInstallerScan.h
+++ b/Boxer/BXInstallerScan.h
@@ -17,15 +17,6 @@
 /// It also collects overall file data about the source while scanning, such as the game profile
 /// and whether the game appears to be already installed (or not a DOS game at all).
 @interface BXInstallerScan : ADBImageAwareFileScan
-{
-    NSMutableArray<NSString*> *_windowsExecutables;
-    NSMutableArray<NSString*> *_DOSExecutables;
-    NSMutableArray<NSString*> *_macOSApps;
-    NSMutableArray<NSString*> *_DOSBoxConfigurations;
-    BOOL _alreadyInstalled;
-    
-    BXGameProfile *_detectedProfile;
-} 
 
 /// The relative paths of all DOS and Windows executables and DOSBox configuration files
 /// discovered during scanning.

--- a/Boxer/BXInstallerScan.m
+++ b/Boxer/BXInstallerScan.m
@@ -34,12 +34,6 @@
 @end
 
 @implementation BXInstallerScan
-@synthesize windowsExecutables      = _windowsExecutables;
-@synthesize DOSExecutables          = _DOSExecutables;
-@synthesize DOSBoxConfigurations    = _DOSBoxConfigurations;
-@synthesize macOSApps               = _macOSApps;
-@synthesize alreadyInstalled        = _alreadyInstalled;
-@synthesize detectedProfile         = _detectedProfile;
 
 - (id) init
 {

--- a/Boxer/BXJoypadController.h
+++ b/Boxer/BXJoypadController.h
@@ -12,11 +12,7 @@
 #import "JoypadSDK.h"
 
 @interface BXJoypadController : NSObject <JoypadManagerDelegate>
-{
-    JoypadManager *joypadManager;
-    JoypadControllerLayout *currentLayout;
-    BOOL hasJoypadDevices;
-}
+
 @property (strong, readonly, nonatomic) JoypadManager *joypadManager;
 
 /// An array of all currently-connected joypad devices being used by Boxer.

--- a/Boxer/BXJoypadController.m
+++ b/Boxer/BXJoypadController.m
@@ -27,33 +27,31 @@
 
 @implementation BXJoypadController
 
-@synthesize joypadManager, currentLayout, hasJoypadDevices;
-
 #pragma mark -
 #pragma mark Initialization and deallocation
 
 - (void) setCurrentLayout: (JoypadControllerLayout *)layout
 {
-    if (currentLayout != layout)
+    if (_currentLayout != layout)
     {
-        currentLayout = layout;
+        _currentLayout = layout;
         
         if (layout)
         {
-            [joypadManager setControllerLayout: layout];
+            [self.joypadManager setControllerLayout: layout];
         }
     }
 }
 
 - (void) awakeFromNib
 {
-    joypadManager = [[JoypadManager alloc] init];
-    [joypadManager setDelegate: self];
-    [joypadManager setMaxPlayerCount: 1];
+    _joypadManager = [[JoypadManager alloc] init];
+    [self.joypadManager setDelegate: self];
+    [self.joypadManager setMaxPlayerCount: 1];
     
     //Default to a 4-button layout (this may be overridden by any game the user starts)
     [self setCurrentLayout: [BX4ButtonJoystickLayout layout]];
-    [joypadManager startFindingDevices];
+    [self.joypadManager startFindingDevices];
     
     BXBaseAppController *appController = (BXBaseAppController *)[NSApp delegate];
     [appController addObserver: self
@@ -73,7 +71,7 @@
     [appController removeObserver: self forKeyPath: @"currentSession.DOSWindowController.inputController.currentJoypadLayout"];
     [appController removeObserver: self forKeyPath: @"currentSession.DOSWindowController.inputController"];
     
-    [joypadManager stopFindingDevices];
+    [self.joypadManager stopFindingDevices];
     [self setCurrentLayout: nil];
 }
 
@@ -83,7 +81,7 @@
 
 - (NSArray *) joypadDevices
 {
-    return [joypadManager connectedDevices];
+    return [self.joypadManager connectedDevices];
 }
 
 - (BXInputController *) activeWindowController

--- a/Boxer/BXJoystickController.h
+++ b/Boxer/BXJoystickController.h
@@ -14,10 +14,7 @@
 /// These messages are then translated into a more Boxer-friendly format and sent onwards to the
 /// active DOS session's input controller.
 @interface BXJoystickController: NSObject <ADBHIDMonitorDelegate, DDHidJoystickDelegate>
-{
-	ADBHIDMonitor *_HIDMonitor;
-    NSArray *_recentHIDRemappers;
-}
+
 @property (readonly, strong, nonatomic) ADBHIDMonitor *HIDMonitor;
 
 /// An array of\c  DDHIDJoystick instances for each joystick currently connected.

--- a/Boxer/BXJoystickController.m
+++ b/Boxer/BXJoystickController.m
@@ -24,8 +24,6 @@
 @end
 
 @implementation BXJoystickController
-@synthesize HIDMonitor = _HIDMonitor;
-@synthesize recentHIDRemappers = _recentHIDRemappers;
 
 - (id) init
 {

--- a/Boxer/BXKeyboardEventTap.h
+++ b/Boxer/BXKeyboardEventTap.h
@@ -29,17 +29,6 @@ typedef NS_ENUM(NSInteger, BXKeyboardEventTapStatus) {
 /// Manages a low-level event tap that captures keyboard events, giving Boxer the ability to respond to them
 /// (and potentially swallow them) before they reach the system and trigger system-wide hotkey functions.
 @interface BXKeyboardEventTap : NSObject
-{
-    ADBContinuousThread *_tapThread;
-    CFMachPortRef _tap;
-    CFRunLoopSourceRef _source;
-    BOOL _enabled;
-    BOOL _usesDedicatedThread;
-    BOOL _restartNeeded;
-    BXKeyboardEventTapStatus _status;
-    
-    __unsafe_unretained id <BXKeyboardEventTapDelegate> _delegate;
-}
 
 /// Whether OS X has granting the application permission to capture keyup and keydown events.
 /// In OS X 10.8 and below, this will be YES if the accessibility API is enabled: i.e. "Enable access for assistive devices" is turned on.
@@ -49,7 +38,7 @@ typedef NS_ENUM(NSInteger, BXKeyboardEventTapStatus) {
 + (BOOL) canCaptureKeyEvents;
 
 /// The delegate whom we will ask for event-capture decisions.
-@property (assign) id <BXKeyboardEventTapDelegate> delegate;
+@property (weak) id <BXKeyboardEventTapDelegate> delegate;
 
 /// Whether the event tap should capture system hotkeys and media keys.
 /// Toggling this will attach/detach the event tap.

--- a/Boxer/BXKeyboardEventTap.m
+++ b/Boxer/BXKeyboardEventTap.m
@@ -48,12 +48,10 @@ static CGEventRef _handleEventFromTap(CGEventTapProxy proxy, CGEventType type, C
 
 
 @implementation BXKeyboardEventTap
-@synthesize enabled = _enabled;
-@synthesize usesDedicatedThread = _usesDedicatedThread;
-@synthesize tapThread = _tapThread;
-@synthesize delegate = _delegate;
-@synthesize status = _status;
-@synthesize restartNeeded = _restartNeeded;
+{
+	CFMachPortRef _tap;
+	CFRunLoopSourceRef _source;
+}
 
 - (id) init
 {

--- a/Boxer/BXMIDIDeviceMonitor.h
+++ b/Boxer/BXMIDIDeviceMonitor.h
@@ -35,13 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// (This work is moved to a thread because CoreMIDI initialization is fairly costly, and would
 /// otherwise block application startup. Besides improved startup time, there are no other benefits.)
 @interface BXMIDIDeviceMonitor : ADBContinuousThread <BXMIDIInputListenerDelegate>
-{
-    MIDIClientRef _client;
-    MIDIPortRef _outputPort;
-    MIDIPortRef _inputPort;
-    NSMutableArray *_discoveredMT32s;
-    NSMutableArray *_listeners;
-}
 
 /// An array of unique destination IDs for MT-32s found during our scan.
 /// This will be populated and depopulated as devices are added and removed.
@@ -65,15 +58,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// it always delivers notifications about that data on the thread upon which
 /// \c listenToSource:onPort:contextInfo: was called.
 @interface BXMIDIInputListener : NSObject
-{
-    __unsafe_unretained id <BXMIDIInputListenerDelegate> _delegate;
-    MIDIPortRef _port;
-    MIDIEndpointRef _source;
-    void * _contextInfo;
-    NSTimeInterval _timeout;
-    NSMutableData *_receivedData;
-    NSThread *_notificationThread;
-}
 
 # pragma mark -
 # pragma mark Properties
@@ -101,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) NSTimeInterval timeout;
 
 //The delegate to which notification messages will be sent.
-@property (assign, nonatomic, nullable) id <BXMIDIInputListenerDelegate> delegate;
+@property (weak, nonatomic) id <BXMIDIInputListenerDelegate> delegate;
 
 
 # pragma mark -

--- a/Boxer/BXMIDIDeviceMonitor.h
+++ b/Boxer/BXMIDIDeviceMonitor.h
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// be told to stop manually with stopListening.
 @property (assign, nonatomic) NSTimeInterval timeout;
 
-//The delegate to which notification messages will be sent.
+/// The delegate to which notification messages will be sent.
 @property (weak, nonatomic) id <BXMIDIInputListenerDelegate> delegate;
 
 

--- a/Boxer/BXMIDIDeviceMonitor.m
+++ b/Boxer/BXMIDIDeviceMonitor.m
@@ -58,7 +58,13 @@ void _didReceiveMIDINotification(const MIDINotification *message, void *context)
 #pragma mark Implementation
 
 @implementation BXMIDIDeviceMonitor
-@synthesize discoveredMT32s = _discoveredMT32s;
+{
+	MIDIClientRef _client;
+	MIDIPortRef _outputPort;
+	MIDIPortRef _inputPort;
+	NSMutableArray *_discoveredMT32s;
+	NSMutableArray *_listeners;
+}
 
 #pragma mark -
 #pragma mark Public API
@@ -393,13 +399,10 @@ void _didReceiveMIDINotification(const MIDINotification *message, void *context)
 @end
 
 @implementation BXMIDIInputListener
-@synthesize port = _port;
-@synthesize source = _source;
-@synthesize contextInfo = _contextInfo;
-@synthesize timeout = _timeout;
-@synthesize delegate = _delegate;
-@synthesize receivedData = _receivedData;
-
+{
+	NSMutableData *_receivedData;
+	NSThread *_notificationThread;
+}
 
 #pragma mark -
 #pragma mark Class helpers

--- a/Boxer/BXMIDISynth.h
+++ b/Boxer/BXMIDISynth.h
@@ -18,12 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// BXMIDISyth sending MIDI signals from DOSBox to OS X's built-in MIDI synth, using the AUGraph API.
 /// It's largely cribbed from DOSBox's own coreaudio MIDI handler.
 @interface BXMIDISynth : NSObject <BXMIDIDevice>
-{
-	AUGraph _graph;
-	AudioUnit _synthUnit;
-	AudioUnit _outputUnit;
-    NSURL *_soundFontURL;
-}
 
 /// The URL of the soundfont bank we are currently using,
 /// which be the default system unless a custom one has been

--- a/Boxer/BXMIDISynth.m
+++ b/Boxer/BXMIDISynth.m
@@ -24,8 +24,11 @@
 #pragma mark Implementation
 
 @implementation BXMIDISynth
-@synthesize soundFontURL = _soundFontURL;
-
+{
+	AUGraph _graph;
+	AudioUnit _synthUnit;
+	AudioUnit _outputUnit;
+}
 
 #pragma mark -
 #pragma mark Initialization and cleanup

--- a/Boxer/BXMT32ROMDropzone.h
+++ b/Boxer/BXMT32ROMDropzone.h
@@ -11,21 +11,8 @@
 
 
 @interface BXMT32ROMDropzone : NSButton <CALayerDelegate>
-{
-    BXMT32ROMType _ROMType;
-    
-    CALayer *_backgroundLayer;
-    CALayer *_CM32LLayer;
-    CALayer *_MT32Layer;
-    CALayer *_highlightLayer;
-    CATextLayer *_titleLayer;
-}
 
 /// The type of MT-32 device to display (or BXMT32ROMTypeUnknown for no device.)
 @property (assign, nonatomic) BXMT32ROMType ROMType;
-
-//Whether the dropzone is highlighted for a drag-drop operation.
-//We now use NSControl's highlighted property.
-//@property (assign, atomic, getter=isHighlighted) BOOL highlighted;
 
 @end

--- a/Boxer/BXMT32ROMDropzone.m
+++ b/Boxer/BXMT32ROMDropzone.m
@@ -28,12 +28,6 @@
 #pragma mark Implementation
 
 @implementation BXMT32ROMDropzone
-@synthesize ROMType = _ROMType;
-@synthesize backgroundLayer = _backgroundLayer;
-@synthesize CM32LLayer = _CM32LLayer;
-@synthesize MT32Layer = _MT32Layer;
-@synthesize highlightLayer = _highlightLayer;
-@synthesize titleLayer = _titleLayer;
 
 - (void) awakeFromNib
 {

--- a/Boxer/BXMountPanelController.h
+++ b/Boxer/BXMountPanelController.h
@@ -15,20 +15,13 @@
 /// It is responsible for synchronising the drive-settings fields with the current file selection, 
 /// and for calling the relevant mount commands once a file is chosen.
 @interface BXMountPanelController : NSViewController <NSOpenSavePanelDelegate>
-{
-	NSPopUpButton *_driveType;
-	NSPopUpButton *_driveLetter;
-	NSButton *_readOnlyToggle;
-	
-	NSCellStateValue _previousReadOnlyState;
-	NSMenuItem *_previousDriveTypeSelection;
-}
+
 /// The drive type selector in the accessory view.
-@property (strong) IBOutlet NSPopUpButton *driveType;
+@property (strong, nonatomic) IBOutlet NSPopUpButton *driveType;
 /// The drive letter selector in the accessory view.
-@property (strong) IBOutlet NSPopUpButton *driveLetter;
+@property (strong, nonatomic) IBOutlet NSPopUpButton *driveLetter;
 /// The read-only checkbox toggle in the accessory view.
-@property (strong) IBOutlet NSButton *readOnlyToggle;	
+@property (strong, nonatomic) IBOutlet NSButton *readOnlyToggle;
 
 /// Returns a singleton instance, which loads the view from the NIB file the first time.
 @property (class, readonly, strong) id controller;

--- a/Boxer/BXMountPanelController.m
+++ b/Boxer/BXMountPanelController.m
@@ -18,9 +18,10 @@
 
 
 @implementation BXMountPanelController
-@synthesize driveType = _driveType;
-@synthesize driveLetter = _driveLetter;
-@synthesize readOnlyToggle = _readOnlyToggle;
+{
+	NSCellStateValue _previousReadOnlyState;
+	NSMenuItem *_previousDriveTypeSelection;
+}
 
 + (id) controller
 {

--- a/Boxer/BXPreferencesController.h
+++ b/Boxer/BXPreferencesController.h
@@ -14,21 +14,6 @@
 /// BXPreferencesController manages Boxer's application-wide preferences panel.
 /// It is a singleton, and once opened for the first time it stays alive throughout the lifetime of the application.
 @interface BXPreferencesController : ADBTabbedWindowController <NSOpenSavePanelDelegate>
-{
-    BXFilterGallery *_filterGallery;
-    NSPopUpButton *_gamesFolderSelector;
-	NSMenuItem *_currentGamesFolderItem;
-    BXMT32ROMDropzone *_MT32ROMDropzone;
-    NSView *_missingMT32ROMHelp;
-    NSView *_realMT32Help;
-    NSView *_MT32ROMOptions;
-    
-    NSButton *_hotkeyCaptureToggle;
-    NSTextField *_hotkeyCaptureDescription;
-    NSTextField *_hotkeyCaptureExtraHelp;
-    NSTextField *_hotkeyCaptureDisabledHelp;
-    NSButton *_hotkeyCapturePermissionsButton;
-}
 
 /// The filter gallery view from which the user can choose the active rendering style.
 @property (strong, nonatomic) IBOutlet BXFilterGallery *filterGallery;

--- a/Boxer/BXPreferencesController.m
+++ b/Boxer/BXPreferencesController.m
@@ -60,22 +60,6 @@ enum {
 
 @implementation BXPreferencesController
 
-@synthesize gamesFolderSelector = _gamesFolderSelector;
-@synthesize currentGamesFolderItem = _currentGamesFolderItem;
-
-@synthesize filterGallery = _filterGallery;
-
-@synthesize MT32ROMDropzone = _MT32ROMDropzone;
-@synthesize missingMT32ROMHelp = _missingMT32ROMHelp;
-@synthesize realMT32Help = _realMT32Help;
-@synthesize MT32ROMOptions = _MT32ROMOptions;
-
-@synthesize hotkeyCaptureToggle = _hotkeyCaptureToggle;
-@synthesize hotkeyCaptureDescription = _hotkeyCaptureDescription;
-@synthesize hotkeyCaptureExtraHelp = _hotkeyCaptureExtraHelp;
-@synthesize hotkeyCapturePermissionsButton = _hotkeyCapturePermissionsButton;
-
-
 #pragma mark - Initialization and deallocation
 
 + (BXPreferencesController *) controller

--- a/Boxer/BXScriptableWindow.h
+++ b/Boxer/BXScriptableWindow.h
@@ -23,9 +23,6 @@
 /// This allows a unified Applescript interface for dealing with a window and its controller as a unit,
 /// without overloading the window with controller logic.
 @interface BXScriptableWindow : NSObject
-{
-	NSWindow *window;
-}
 
 @property (strong, nonatomic) NSWindow *window;
 

--- a/Boxer/BXScriptableWindow.m
+++ b/Boxer/BXScriptableWindow.m
@@ -9,7 +9,6 @@
 
 
 @implementation BXScriptableWindow
-@synthesize window;
 
 #pragma mark -
 #pragma mark Introspection

--- a/Boxer/BXShelfArt.h
+++ b/Boxer/BXShelfArt.h
@@ -12,10 +12,8 @@
 /// \c BXShelfArt generates tiled shelf artwork for Finder folders. It can return an NSImage resource
 /// suitable for saving as a file, or draw the art directly into the current graphics context.
 @interface BXShelfArt : NSObject
-{
-	NSImage *sourceImage;
-}
-/// The original image we will render into tiled shelf art
+
+/// The original image we will render into tiled shelf art.
 @property (strong) NSImage *sourceImage;
 
 #pragma mark -

--- a/Boxer/BXShelfArt.m
+++ b/Boxer/BXShelfArt.m
@@ -8,7 +8,6 @@
 #import "BXShelfArt.h"
 
 @implementation BXShelfArt
-@synthesize sourceImage;
 
 - (id) initWithSourceImage: (NSImage *)image
 {

--- a/Boxer/BXSimpleDriveImport.h
+++ b/Boxer/BXSimpleDriveImport.h
@@ -13,9 +13,4 @@
 
 /// \c BXSimpleDriveImport handles the importing of a drive to a specified destination.
 @interface BXSimpleDriveImport : ADBSingleFileTransfer <BXDriveImport>
-{
-	BXDrive *_drive;
-	NSURL *_destinationFolderURL;
-	NSURL *_destinationURL;
-}
 @end

--- a/Boxer/BXThemedImageCell.h
+++ b/Boxer/BXThemedImageCell.h
@@ -13,16 +13,9 @@
 
 /// \c BXThemeImageCell renders its image as a template using a fill and shadow effects defined in a theme.
 @interface BXThemedImageCell : NSImageCell <BXThemable>
-{
-    NSString *_themeKey;
-}
 
 /// The current theme key.
 @property (copy, nonatomic) NSString *themeKey;
-
-//Toggles the highlighted appearance for the image cell.
-//We now use NSControl's highlighted property.
-//@property (assign, getter=isHighlighted) BOOL highlighted;
 
 @end
 

--- a/Boxer/BXThemedProgressIndicator.h
+++ b/Boxer/BXThemedProgressIndicator.h
@@ -11,10 +11,6 @@
 /// BXHUDProgressIndicator is a translucent white progress indicator designed
 /// for HUD panels.
 @interface BXThemedProgressIndicator: NSProgressIndicator <BXThemable>
-{
-    NSString *_themeKey;
-    NSTimer *_animationTimer;
-}
 
 /// Draw methods called from drawRect:
 - (NSBezierPath *) stripePathForFrame: (NSRect)frame

--- a/Boxer/BXThemedProgressIndicator.m
+++ b/Boxer/BXThemedProgressIndicator.m
@@ -20,7 +20,6 @@
 @end
 
 @implementation BXThemedProgressIndicator
-@synthesize animationTimer = _animationTimer;
 @synthesize themeKey = _themeKey;
 
 - (void) dealloc

--- a/Boxer/BXValueTransformers.h
+++ b/Boxer/BXValueTransformers.h
@@ -16,9 +16,6 @@
 
 /// A simple value transformer that wraps an NSDateFormatter instance.
 @interface BXDateTransformer : NSValueTransformer
-{
-    NSDateFormatter *_formatter;
-}
 @property (strong, nonatomic) NSDateFormatter *formatter;
 
 - (id) initWithDateFormatter: (NSDateFormatter *)formatter;
@@ -31,11 +28,6 @@
 /// Note that this transformer stores state internally, which means it must not be shared between multiple
 /// input sources.
 @interface BXRollingAverageTransformer : NSValueTransformer
-{
-	float _previousAverage;
-    BOOL _hasAverage;
-	NSUInteger _windowSize;
-}
 - (id) initWithWindowSize: (NSUInteger)size;
 
 @end
@@ -43,12 +35,8 @@
 /// Returns the NSNumber equivalents of \c YES or \c NO based on whether an array's size is within the min and max range of the transformer.
 /// Registered as \c BXIsEmpty and \c BXIsNotEmpty by BXAppController, which are used for detecting whether an array is empty or not.
 @interface BXArraySizeTransformer : NSValueTransformer
-{
-	NSUInteger _minSize;
-	NSUInteger _maxSize;
-}
-@property (assign, nonatomic) NSUInteger minSize;
-@property (assign, nonatomic) NSUInteger maxSize;
+@property (nonatomic) NSUInteger minSize;
+@property (nonatomic) NSUInteger maxSize;
 
 - (id) initWithMinSize: (NSUInteger)min maxSize: (NSUInteger)max;
 @end
@@ -65,10 +53,6 @@
 /// NOTE: sliders using this transformer must have a range from 0.0 to 1.0.
 #define MAX_BANDS 32
 @interface BXBandedValueTransformer: NSValueTransformer
-{
-	double _bandThresholds[MAX_BANDS];
-    NSUInteger _numBands;
-}
 
 - (id) initWithThresholds: (double *)thresholds count: (NSUInteger)count;
 - (void) setThresholds: (double *)thresholds count: (NSUInteger)count;
@@ -94,16 +78,10 @@
 
 /// Converts a POSIX file path into a representation suitable for display.
 @interface BXDisplayPathTransformer: NSValueTransformer
-{
-	NSString *_joiner;
-	NSString *_ellipsis;
-	NSUInteger _maxComponents;
-	BOOL _usesFilesystemDisplayPath;
-}
 @property (copy, nonatomic) NSString *joiner;
 @property (copy, nonatomic) NSString *ellipsis;
-@property (assign, nonatomic) NSUInteger maxComponents;
-@property (assign, nonatomic) BOOL usesFilesystemDisplayPath;
+@property (nonatomic) NSUInteger maxComponents;
+@property (nonatomic) BOOL usesFilesystemDisplayPath;
 
 - (id) initWithJoiner: (NSString *)joinString
 			 ellipsis: (NSString *)ellipsisString
@@ -118,13 +96,7 @@
 /// for each part of the file path. Unlike BXDisplayPathTransformer, this returns
 /// an \c NSAttributedString rather than an NSString.
 @interface BXIconifiedDisplayPathTransformer: BXDisplayPathTransformer
-{
-	NSImage *_missingFileIcon;
-	NSMutableDictionary *_textAttributes;
-	NSMutableDictionary *_iconAttributes;
-	NSSize _iconSize;
-	BOOL _hidesSystemRoots;
-}
+
 /// The file icon to use for files/folders that don't yet exist.
 /// If left as nil, will use NSWorkspace's default icon for missing files.
 @property (copy, nonatomic) NSImage *missingFileIcon;
@@ -138,11 +110,11 @@
 @property (strong, nonatomic) NSMutableDictionary *iconAttributes;
 
 /// The pixel size at which to display icons. Defaults to 16x16.
-@property (assign, nonatomic) NSSize iconSize;
+@property (nonatomic) NSSize iconSize;
 
 /// Whether to hide the / and /Users/ subpaths in displayed paths.
 /// This imitates the behaviour of \c NSPathControl et. al.
-@property (assign, nonatomic) BOOL hidesSystemRoots;
+@property (nonatomic) BOOL hidesSystemRoots;
 
 /// Returns an icon-and-label attributed string for the specified path.
 /// defaultIcon specifies the icon to use if the path does not exist.
@@ -157,10 +129,8 @@
 
 /// Resizes an NSImage to the target size.
 @interface BXImageSizeTransformer: NSValueTransformer
-{
-	NSSize _size;
-}
-@property (assign, nonatomic) NSSize size;
+
+@property (nonatomic) NSSize size;
 
 - (id) initWithSize: (NSSize)targetSize;
 

--- a/Boxer/BXValueTransformers.m
+++ b/Boxer/BXValueTransformers.m
@@ -14,7 +14,6 @@
 #pragma mark Date transformers
 
 @implementation BXDateTransformer
-@synthesize formatter = _formatter;
 
 + (Class) transformedValueClass			{ return [NSString class]; }
 + (BOOL) allowsReverseTransformation	{ return YES; }
@@ -45,6 +44,11 @@
 #pragma mark Numeric transformers
 
 @implementation BXRollingAverageTransformer
+{
+	float _previousAverage;
+	BOOL _hasAverage;
+	NSUInteger _windowSize;
+}
 
 + (Class) transformedValueClass			{ return [NSNumber class]; }
 + (BOOL) allowsReverseTransformation	{ return NO; }
@@ -88,8 +92,6 @@
 
 
 @implementation BXArraySizeTransformer
-@synthesize minSize = _minSize;
-@synthesize maxSize = _maxSize;
 
 + (Class) transformedValueClass			{ return [NSNumber class]; }
 + (BOOL) allowsReverseTransformation	{ return NO; }
@@ -124,6 +126,10 @@
 
 
 @implementation BXBandedValueTransformer
+{
+	double _bandThresholds[MAX_BANDS];
+	NSUInteger _numBands;
+}
 
 + (Class) transformedValueClass			{ return [NSNumber class]; }
 + (BOOL) allowsReverseTransformation	{ return YES; }
@@ -281,10 +287,6 @@
 
 
 @implementation BXDisplayPathTransformer
-@synthesize joiner = _joiner;
-@synthesize ellipsis = _ellipsis;
-@synthesize maxComponents = _maxComponents;
-@synthesize usesFilesystemDisplayPath = _usesFilesystemDisplayPath;
 
 + (Class) transformedValueClass			{ return [NSString class]; }
 + (BOOL) allowsReverseTransformation	{ return NO; }
@@ -353,11 +355,6 @@
 
 
 @implementation BXIconifiedDisplayPathTransformer
-@synthesize missingFileIcon = _missingFileIcon;
-@synthesize textAttributes = _textAttributes;
-@synthesize iconAttributes = _iconAttributes;
-@synthesize iconSize = _iconSize;
-@synthesize hidesSystemRoots = _hidesSystemRoots;
 
 + (Class) transformedValueClass { return [NSAttributedString class]; }
 
@@ -481,7 +478,6 @@
 #pragma mark Image transformers
 
 @implementation BXImageSizeTransformer
-@synthesize size = _size;
 
 + (Class) transformedValueClass			{ return [NSImage class]; }
 + (BOOL) allowsReverseTransformation	{ return NO; }

--- a/Boxer/BXWelcomeView.h
+++ b/Boxer/BXWelcomeView.h
@@ -22,11 +22,10 @@
 @end
 
 @interface BXWelcomeButton : BXFilterPortrait
-{
-	__unsafe_unretained id <BXWelcomeButtonDraggingDelegate> _draggingDelegate;
-}
+
 /// The delegate used for drag-drop operations.
-@property (assign) IBOutlet id <BXWelcomeButtonDraggingDelegate> draggingDelegate;
+@property (weak, nonatomic) IBOutlet id <BXWelcomeButtonDraggingDelegate> draggingDelegate;
+
 - (BOOL) isHighlighted;
 
 @end

--- a/Boxer/BXWelcomeView.m
+++ b/Boxer/BXWelcomeView.m
@@ -40,7 +40,6 @@
 
 
 @implementation BXWelcomeButton
-@synthesize draggingDelegate = _draggingDelegate;
 
 - (void) awakeFromNib
 {

--- a/Boxer/BXWelcomeWindowController.h
+++ b/Boxer/BXWelcomeWindowController.h
@@ -13,24 +13,18 @@
 
 /// \c BXWelcomeWindowController manages the welcome window shown when Boxer launches.
 @interface BXWelcomeWindowController : NSWindowController <BXWelcomeButtonDraggingDelegate>
-{
-	IBOutlet NSPopUpButton *__weak recentDocumentsButton;
-	IBOutlet BXWelcomeButton *__weak importGameButton;
-	IBOutlet BXWelcomeButton *__weak openPromptButton;
-	IBOutlet BXWelcomeButton *__weak showGamesFolderButton;
-}
 
 /// The Open Recent popup button.
-@property (weak, nonatomic) NSPopUpButton *recentDocumentsButton;
+@property (strong, nonatomic) IBOutlet NSPopUpButton *recentDocumentsButton;
 
 /// The import-a-new-game button. Drag-drop events onto this button will be handled by this controller.
-@property (weak, nonatomic) BXWelcomeButton *importGameButton;
+@property (strong, nonatomic) IBOutlet BXWelcomeButton *importGameButton;
 
 /// The open-DOS-prompt button. Drag-drop events onto this button will be handled by this controller.
-@property (weak, nonatomic) BXWelcomeButton *openPromptButton;
+@property (strong, nonatomic) IBOutlet BXWelcomeButton *openPromptButton;
 
 /// The browse-games-folder button. Has no special behaviour.
-@property (weak, nonatomic) BXWelcomeButton *showGamesFolderButton;
+@property (strong, nonatomic) IBOutlet BXWelcomeButton *showGamesFolderButton;
 
 
 /// Provides a singleton instance of the window controller which stays retained for the lifetime

--- a/Boxer/BXWelcomeWindowController.m
+++ b/Boxer/BXWelcomeWindowController.m
@@ -33,7 +33,6 @@
 
 
 @implementation BXWelcomeWindowController
-@synthesize recentDocumentsButton, importGameButton, openPromptButton, showGamesFolderButton;
 
 #pragma mark -
 #pragma mark Initialization and deallocation

--- a/Boxer/DOS window/BXDOSWindow.h
+++ b/Boxer/DOS window/BXDOSWindow.h
@@ -18,9 +18,7 @@
 /// \c BXDOSWindowController and exists mainly just to override <code>NSWindow</code>'s default window sizing
 /// and constraining methods.
 @interface BXDOSWindow : ADBFullscreenCapableWindow
-{
-    NSView *actualContentView;
-}
+
 /// The 'real' content view by which our content size calculations will be constrained,
 /// and which will fill the screen in fullscreen mode. This is distinct from the window's
 /// top-level content view and does not include the program panel or statusbar views.

--- a/Boxer/DOS window/BXDOSWindow.m
+++ b/Boxer/DOS window/BXDOSWindow.m
@@ -12,12 +12,6 @@
 #define BXFrameResizeDelayFalloff 7.5
 
 @implementation BXDOSWindow
-@synthesize actualContentView;
-
-- (void) dealloc
-{
-    [self setActualContentView: nil];
-}
 
 //Overridden to smooth out the speed of shorter resize animations,
 //while leaving larger resize animations largely as they were.

--- a/Boxer/DOS window/BXDOSWindowBackgroundView.h
+++ b/Boxer/DOS window/BXDOSWindowBackgroundView.h
@@ -9,9 +9,6 @@
 
 /// BXDOSWindowBackgroundView simply renders the badged grey gradient background of the DOS window.
 @interface BXDOSWindowBackgroundView : NSView
-{
-    NSBitmapImageRep *_snapshot;
-}
 @end
 
 

--- a/Boxer/DOS window/BXDOSWindowBackgroundView.m
+++ b/Boxer/DOS window/BXDOSWindowBackgroundView.m
@@ -11,7 +11,6 @@
 #import "NSView+ADBDrawingHelpers.h"
 
 @implementation BXDOSWindowBackgroundView
-@synthesize snapshot = _snapshot;
 
 - (void) _drawBackgroundInRect: (NSRect)dirtyRect
 {

--- a/Boxer/DOS window/BXDOSWindowController.h
+++ b/Boxer/DOS window/BXDOSWindowController.h
@@ -51,38 +51,6 @@ extern NSString * const BXViewDidLiveResizeNotification;
 /// Besides the usual window-controller responsibilities, it handles switching to and from fullscreen
 /// and passing frames to the emulator to the rendering view.
 @interface BXDOSWindowController : NSWindowController <ADBFullScreenCapableWindowDelegate>
-{
-    NSView <BXFrameRenderingView> *_renderingView;
-	BXInputView *_inputView;
-	NSView *_statusBar;
-	NSView *_programPanel;
-    NSView *_launchPanel;
-    NSView *_loadingPanel;
-    NSView *_panelWrapper;
-    NSSegmentedControl *_panelToggle;
-    YRKSpinningProgressIndicator *_loadingSpinner;
-
-	BXProgramPanelController *_programPanelController;
-	BXInputController *_inputController;
-	BXStatusBarController *_statusBarController;
-    BXLaunchPanelController *_launchPanelController;
-    
-    NSToolbarItem *_documentationButton;
-	
-    NSSize _currentScaledSize;
-	NSSize _currentScaledResolution;
-    BOOL _aspectCorrected;
-	BOOL _resizingProgrammatically;
-    BOOL _windowIsClosing;
-    
-    NSSize _renderingViewSizeBeforeFullScreen;
-    NSString *_autosaveNameBeforeFullScreen;
-    
-    NSSize _maxFullscreenViewportSize;
-    
-    BXDOSWindowPanel _currentPanel;
-    BXRenderingStyle _renderingStyle;
-}
 
 #pragma mark - Properties
 

--- a/Boxer/DOS window/BXDOSWindowController.m
+++ b/Boxer/DOS window/BXDOSWindowController.m
@@ -41,28 +41,18 @@
 NSString * const BXDOSWindowFullscreenSizeFormat = @"Fullscreen size for %@";
 
 @implementation BXDOSWindowController
+{
+	NSSize _renderingViewSizeBeforeFullScreen;
+	BOOL _resizingProgrammatically;
+	BOOL _windowIsClosing;
+	
+	NSSize _currentScaledSize;
+	NSSize _currentScaledResolution;
+}
+
 
 #pragma mark -
 #pragma mark Accessors
-
-@synthesize renderingView = _renderingView;
-@synthesize inputView = _inputView;
-@synthesize currentPanel = _currentPanel;
-@synthesize statusBar = _statusBar;
-@synthesize programPanel = _programPanel;
-@synthesize launchPanel = _launchPanel;
-@synthesize panelWrapper = _panelWrapper;
-@synthesize programPanelController = _programPanelController;
-@synthesize launchPanelController = _launchPanelController;
-@synthesize inputController = _inputController;
-@synthesize statusBarController = _statusBarController;
-@synthesize autosaveNameBeforeFullScreen = _autosaveNameBeforeFullScreen;
-@synthesize aspectCorrected = _aspectCorrected;
-@synthesize loadingPanel = _loadingPanel;
-@synthesize loadingSpinner = _loadingSpinner;
-@synthesize documentationButton = _documentationButton;
-@synthesize maxFullscreenViewportSize = _maxFullscreenViewportSize;
-@synthesize renderingStyle = _renderingStyle;
 
 - (void) setDocument: (BXSession *)document
 {	

--- a/Boxer/DOS window/BXHUDSpinningProgressIndicator.h
+++ b/Boxer/DOS window/BXHUDSpinningProgressIndicator.h
@@ -11,9 +11,6 @@
 /// \c BXDOSWindowLoadingSpinner is a thin white progress spinner with a drop shadow,
 /// intended for use on dark window backgrounds.
 @interface BXHUDSpinningProgressIndicator : YRKSpinningProgressIndicator
-{
-    NSShadow *_dropShadow;
-}
 
 @property (strong, nonatomic) NSShadow *dropShadow;
 

--- a/Boxer/DOS window/BXHUDSpinningProgressIndicator.m
+++ b/Boxer/DOS window/BXHUDSpinningProgressIndicator.m
@@ -9,7 +9,6 @@
 #import "NSShadow+ADBShadowExtensions.h"
 
 @implementation BXHUDSpinningProgressIndicator
-@synthesize dropShadow = _dropShadow;
 
 - (void) awakeFromNib
 {

--- a/Boxer/DOS window/BXLaunchPanelController.h
+++ b/Boxer/DOS window/BXLaunchPanelController.h
@@ -23,32 +23,10 @@
 @end
 
 @interface BXLaunchPanelController : NSViewController <NSCollectionViewDelegate, NSTextFieldDelegate, BXLauncherItemDelegate>
-{
-    NSCollectionView *__weak _launcherList;
-    NSScrollView *__weak _launcherScrollView;
-    NSSearchField *__weak _filter;
-    
-    NSMutableArray *_filterKeywords;
-    
-    NSMutableArray *_allProgramRows;
-    NSMutableArray *_favoriteProgramRows;
-    NSMutableArray *_recentProgramRows;
-    NSMutableArray *_displayedRows;
-    
-    NSDictionary *_favoritesHeading;
-    NSDictionary *_recentProgramsHeading;
-    NSDictionary *_allProgramsHeading;
-    
-    BOOL _allProgramRowsDirty;
-    BOOL _favoriteProgramRowsDirty;
-    BOOL _recentProgramRowsDirty;
-    
-    BOOL _shouldUpdateImmediately;
-}
 
-@property (weak, nonatomic) IBOutlet NSCollectionView *launcherList;
-@property (weak, nonatomic) IBOutlet NSScrollView *launcherScrollView;
-@property (weak, nonatomic) IBOutlet NSSearchField *filter;
+@property (strong, nonatomic) IBOutlet NSCollectionView *launcherList;
+@property (strong, nonatomic) IBOutlet NSScrollView *launcherScrollView;
+@property (strong, nonatomic) IBOutlet NSSearchField *filter;
 
 /// An array of NSDictionaries for every item to display in the list.
 @property (readonly, strong, nonatomic) NSMutableArray<NSDictionary*> *displayedRows;
@@ -71,24 +49,15 @@
 @class BXLauncherItem;
 /// A custom collection view that uses a different prototype for drive 'headings'
 @interface BXLauncherList : NSCollectionView
-{
-    BXLauncherItem *__weak _headingPrototype;
-    BXLauncherItem *__weak _favoritePrototype;
-}
 
-@property (weak, nonatomic) IBOutlet BXLauncherItem *headingPrototype;
-@property (weak, nonatomic) IBOutlet BXLauncherItem *favoritePrototype;
+@property (strong, nonatomic) IBOutlet BXLauncherItem *headingPrototype;
+@property (strong, nonatomic) IBOutlet BXLauncherItem *favoritePrototype;
 
 @end
 
 @class BXLauncherItemView;
 @interface BXLauncherItem : BXCollectionItem
-{
-    id <BXLauncherItemDelegate> __unsafe_unretained _delegate;
-    BOOL _launchable;
-    NSMenu *_menu;
-}
-@property (unsafe_unretained, nonatomic) IBOutlet id <BXLauncherItemDelegate> delegate;
+@property (weak, nonatomic) IBOutlet id <BXLauncherItemDelegate> delegate;
 @property (assign, nonatomic, getter=isLaunchable) BOOL launchable;
 @property (strong, nonatomic) IBOutlet NSMenu *menu; //The context menu to display for this item.
 
@@ -103,11 +72,6 @@
 
 /// A base class for launcher items that registers mouse-hover events.
 @interface BXLauncherItemView : BXCollectionItemView
-{
-    BOOL _mouseInside;
-    BOOL _active;
-    BOOL _enabled;
-}
 
 /// Typecast to indicate the type of delegate this view expects.
 @property (weak, nonatomic) BXLauncherItem *delegate;

--- a/Boxer/DOS window/BXLaunchPanelController.m
+++ b/Boxer/DOS window/BXLaunchPanelController.m
@@ -38,17 +38,13 @@
 @end
 
 @implementation BXLaunchPanelController
-@synthesize launcherList = _launcherList;
-@synthesize launcherScrollView = _launcherScrollView;
-@synthesize allProgramRows = _allProgramRows;
-@synthesize favoriteProgramRows = _favoriteProgramRows;
-@synthesize recentProgramRows = _recentProgramRows;
-@synthesize favoritesHeading = _favoritesHeading;
-@synthesize recentProgramsHeading = _recentProgramsHeading;
-@synthesize allProgramsHeading = _allProgramsHeading;
-@synthesize displayedRows = _displayedRows;
-@synthesize filter = _filter;
-@synthesize filterKeywords = _filterKeywords;
+{
+	BOOL _allProgramRowsDirty;
+	BOOL _favoriteProgramRowsDirty;
+	BOOL _recentProgramRowsDirty;
+	
+	BOOL _shouldUpdateImmediately;
+}
 
 - (void) awakeFromNib
 {
@@ -781,8 +777,6 @@
 
 
 @implementation BXLauncherList
-@synthesize headingPrototype = _headingPrototype;
-@synthesize favoritePrototype = _favoritePrototype;
 
 - (NSCollectionViewItem *) newItemForRepresentedObject: (NSDictionary *)object
 {
@@ -812,9 +806,6 @@
 
 
 @implementation BXLauncherItem
-@synthesize delegate = _delegate;
-@synthesize launchable = _launchable;
-@synthesize menu = _menu;
 
 - (id) copyWithZone: (NSZone *)zone
 {
@@ -888,9 +879,6 @@
 @end
 
 @implementation BXLauncherItemView
-@synthesize mouseInside = _mouseInside;
-@synthesize active = _active;
-@synthesize enabled = _enabled;
 
 - (void) awakeFromNib
 {

--- a/Boxer/DOS window/BXProgramPanel.h
+++ b/Boxer/DOS window/BXProgramPanel.h
@@ -26,10 +26,12 @@ enum {
 
 /// BXProgramPanel is the containing view for all other panel content. This class draws
 /// itself as a shaded grey gradient background with a grille at the top.
+__deprecated
 @interface BXProgramPanel : NSView
 @end
 
 /// The tracking item for individual programs in the program panel collection view.
+__deprecated
 @interface BXProgramItem : BXCollectionItem
 {
     NSButton *programButton;
@@ -38,10 +40,12 @@ enum {
 @end
 
 /// Overridden to fix button hover state behaviour when scrolling.
+__deprecated
 @interface BXProgramItemButton : NSButton
 @end
 
 /// Custom button appearance for buttons in the program panel collection view.
+__deprecated
 @interface BXProgramItemButtonCell : BXThemedButtonCell
 {
     BOOL mouseIsInside;
@@ -54,6 +58,7 @@ enum {
 
 /// A subclass to fix some hugely annoying redraw bugs
 /// in 10.5's implementation of NSCollectionView
+__deprecated
 @interface BXProgramListView : NSCollectionView
 {
     @private

--- a/Boxer/DOS window/BXProgramPanelController.h
+++ b/Boxer/DOS window/BXProgramPanelController.h
@@ -16,44 +16,28 @@
 ///
 /// TODO: move most of the which-panel-to-show logic upstream into BXSession, which knows a lot
 /// more about what to display. The current implementation is a rat's-nest of bindings and predictions.
+__deprecated
 @interface BXProgramPanelController : NSViewController
-{
-	IBOutlet NSView *programChooserPanel;
-	IBOutlet NSView *defaultProgramPanel;
-	IBOutlet NSView *initialDefaultProgramPanel;
-	IBOutlet NSView *noProgramsPanel;
-    IBOutlet NSView *scanningForProgramsPanel;
-    
-    IBOutlet NSProgressIndicator *scanSpinner;
-    
-	IBOutlet NSCollectionView *programList;
-	IBOutlet NSScrollView *programScroller;
-	
-	NSArray *panelExecutables;
-    
-    NSString *lastActiveProgramPath;
-}
-
 
 #pragma mark -
 #pragma mark Properties
 
-@property (strong, nonatomic) NSView *programChooserPanel;
-@property (strong, nonatomic) NSView *defaultProgramPanel;
-@property (strong, nonatomic) NSView *initialDefaultProgramPanel;
-@property (strong, nonatomic) NSView *noProgramsPanel;
-@property (strong, nonatomic) NSView *scanningForProgramsPanel;
+@property (strong, nonatomic) IBOutlet NSView *programChooserPanel;
+@property (strong, nonatomic) IBOutlet NSView *defaultProgramPanel;
+@property (strong, nonatomic) IBOutlet NSView *initialDefaultProgramPanel;
+@property (strong, nonatomic) IBOutlet NSView *noProgramsPanel;
+@property (strong, nonatomic) IBOutlet NSView *scanningForProgramsPanel;
 
-@property (strong, nonatomic) NSProgressIndicator *scanSpinner;
+@property (strong, nonatomic) IBOutlet NSProgressIndicator *scanSpinner;
 
-@property (strong, nonatomic) NSCollectionView *programList;
-@property (strong, nonatomic) NSScrollView *programScroller;
+@property (strong, nonatomic) IBOutlet NSCollectionView *programList;
+@property (strong, nonatomic) IBOutlet NSScrollView *programScroller;
 
 /// The currently displayed view in the program panel.
 @property (weak, nonatomic) NSView *activePanel;
 
 /// Whether the currently executing program is the default program for its gamebox.
-@property (assign, nonatomic) BOOL activeProgramIsDefault;
+@property (nonatomic) BOOL activeProgramIsDefault;
 
 /// Whether the current session currently has any default program.
 @property (readonly, nonatomic) BOOL hasDefaultTarget;

--- a/Boxer/DOS window/BXProgramPanelController.m
+++ b/Boxer/DOS window/BXProgramPanelController.m
@@ -22,11 +22,6 @@
 @end
 
 @implementation BXProgramPanelController
-@synthesize programList, programScroller, scanSpinner;
-@synthesize defaultProgramPanel, initialDefaultProgramPanel;
-@synthesize programChooserPanel, noProgramsPanel, scanningForProgramsPanel;
-@synthesize panelExecutables;
-@synthesize lastActiveProgramPath;
 
 - (void) dealloc
 {
@@ -132,24 +127,24 @@
 	{	
 		//If we have a default program, show the checkbox version;
 		//also keep showing the checkbox if it's already active
-		if ([self hasDefaultTarget] || [self activePanel] == defaultProgramPanel)
-			panel = defaultProgramPanel;
+		if ([self hasDefaultTarget] || [self activePanel] == self.defaultProgramPanel)
+			panel = self.defaultProgramPanel;
 		//Otherwise, show the Yes/No choice.
 		else
-			panel = initialDefaultProgramPanel;
+			panel = self.initialDefaultProgramPanel;
 	}
 	else if	(session.programURLsOnPrincipalDrive)
 	{
-		panel = programChooserPanel;
+		panel = self.programChooserPanel;
         [self syncProgramButtonStates];
 	}
     else if ([session isScanningForExecutables])
     {
-        panel = scanningForProgramsPanel;
+        panel = self.scanningForProgramsPanel;
     }
     else
     {   
-		panel = noProgramsPanel;
+		panel = self.noProgramsPanel;
     }
 
 	[self setActivePanel: panel];
@@ -157,7 +152,7 @@
 
 - (void) syncProgramButtonStates
 {
-	for (NSView *itemView in [programList subviews])
+	for (NSView *itemView in [self.programList subviews])
 	{
 		NSButton *button = [itemView viewWithTag: BXProgramPanelButtons];
 		

--- a/Boxer/DOS window/BXStatusBarController.h
+++ b/Boxer/DOS window/BXStatusBarController.h
@@ -17,12 +17,13 @@ enum {
 };
 
 /// BXStatusBarController manages the main window's status bar and button states.
+__deprecated
 @interface BXStatusBarController : NSViewController
 
-@property (weak, nonatomic) IBOutlet NSSegmentedControl *statusBarControls;
-@property (weak, nonatomic) IBOutlet NSTextField *notificationMessage;
-@property (weak, nonatomic) IBOutlet NSButton *mouseLockButton;
-@property (weak, nonatomic) IBOutlet NSView *volumeControls;
+@property (strong, nonatomic) IBOutlet NSSegmentedControl *statusBarControls;
+@property (strong, nonatomic) IBOutlet NSTextField *notificationMessage;
+@property (strong, nonatomic) IBOutlet NSButton *mouseLockButton;
+@property (strong, nonatomic) IBOutlet NSView *volumeControls;
 
 /// The window controller for the window containing this statusbar
 @property (weak, readonly, nonatomic) BXDOSWindowController *controller;

--- a/Boxer/DOS window/BXStatusBarController.m
+++ b/Boxer/DOS window/BXStatusBarController.m
@@ -35,10 +35,6 @@
 @end
 
 @implementation BXStatusBarController
-@synthesize notificationMessage = _notificationMessage;
-@synthesize statusBarControls = _statusBarControls;
-@synthesize volumeControls = _volumeControls;
-@synthesize mouseLockButton = _mouseLockButton;
 
 - (BXDOSWindowController *)controller
 {

--- a/Boxer/Documentation Panel/BXDocumentationBrowser.h
+++ b/Boxer/Documentation Panel/BXDocumentationBrowser.h
@@ -16,17 +16,6 @@
 
 /// BXDocumentationBrowser manages the list of documentation for the gamebox.
 @interface BXDocumentationBrowser : NSViewController <NSCollectionViewDelegate, NSDraggingDestination>
-{
-    NSArray<NSURL*> *_documentationURLs;
-    NSIndexSet *_documentationSelectionIndexes;
-    
-    __weak NSScrollView *_documentationScrollView;
-    __weak BXDocumentationList *_documentationList;
-    __weak NSTextField *_titleLabel;
-    __weak NSTextField *_helpTextLabel;
-    
-    __weak id <BXDocumentationBrowserDelegate> _delegate;
-}
 
 #pragma mark - Properties
 
@@ -34,16 +23,16 @@
 @property (weak, nonatomic) IBOutlet id <BXDocumentationBrowserDelegate> delegate;
 
 /// The scrolling wrapper in which our documenation list is displayed.
-@property (weak, nonatomic) IBOutlet NSScrollView *documentationScrollView;
+@property (strong, nonatomic) IBOutlet NSScrollView *documentationScrollView;
 
 /// The title at the top of the browser.
-@property (weak, nonatomic) IBOutlet NSTextField *titleLabel;
+@property (strong, nonatomic) IBOutlet NSTextField *titleLabel;
 
 /// The help text displayed at the bottom of the browser.
-@property (weak, nonatomic) IBOutlet NSTextField *helpTextLabel;
+@property (strong, nonatomic) IBOutlet NSTextField *helpTextLabel;
 
 /// The collection view in which our documentation will be displayed.
-@property (weak, nonatomic) IBOutlet BXDocumentationList *documentationList;
+@property (strong, nonatomic) IBOutlet BXDocumentationList *documentationList;
 
 /// An array of NSURLs for the documentation files included in this gamebox.
 /// This is mapped directly to the documentation URLs reported by the gamebox.
@@ -52,7 +41,7 @@
 /// An array of criteria for how the documentation files should be sorted in the UI.
 /// Documentation will be sorted by type and then by name, to group similar types
 /// of documentation files together.
-@property (copy, readonly, nonatomic) NSArray<NSSortDescriptor*> *sortCriteria;
+@property (readonly, nonatomic) NSArray<NSSortDescriptor*> *sortCriteria;
 
 /// The currently selected documentation items. Normally, only one item can be selected at a time.
 @property (strong, nonatomic) NSIndexSet *documentationSelectionIndexes;
@@ -66,7 +55,7 @@
 
 /// The text that will be displayed in the help text label at the foot of the view.
 /// Changes depending on how many documentation items there are and whether adding new documentation is possible.
-@property (copy, readonly, nonatomic) NSString *helpText;
+@property (readonly, nonatomic) NSString *helpText;
 
 /// Whether we are able to add or remove documentation from the gamebox.
 /// This is determined from the locked status of the gamebox,
@@ -159,9 +148,6 @@
 
 /// BXDocumentationItem manages each individual documentation file listed in the documentation popup.
 @interface BXDocumentationItem : BXCollectionItem
-{
-    NSImage *_icon;
-}
 
 /// The icon for the documentation file.
 ///
@@ -178,9 +164,6 @@
 
 /// Custom appearance for documentation items. Highlights the background when selected.
 @interface BXDocumentationWrapper : BXCollectionItemView
-{
-    CGFloat _highlightStrength;
-}
 @end
 
 

--- a/Boxer/Documentation Panel/BXDocumentationBrowser.m
+++ b/Boxer/Documentation Panel/BXDocumentationBrowser.m
@@ -36,14 +36,6 @@ enum {
 @end
 
 @implementation BXDocumentationBrowser
-@synthesize documentationScrollView = _documentationScrollView;
-@synthesize documentationList = _documentationList;
-@synthesize titleLabel = _titleLabel;
-@synthesize helpTextLabel = _helpTextLabel;
-
-@synthesize documentationURLs = _documentationURLs;
-@synthesize documentationSelectionIndexes = _documentationSelectionIndexes;
-@synthesize delegate = _delegate;
 
 - (void) setDocumentationSelectionIndexes: (NSIndexSet *)indexes
 {
@@ -654,7 +646,6 @@ enum {
 @end
 
 @implementation BXDocumentationBrowserPreviewItem
-@synthesize originalURL = _originalURL;
 
 + (id) previewItemWithURL: (NSURL *)URL
 {
@@ -793,7 +784,6 @@ enum {
 @end
 
 @implementation BXDocumentationItem
-@synthesize icon = _icon;
 
 - (void) viewDidLoad
 {
@@ -887,7 +877,6 @@ enum {
 @end
 
 @implementation BXDocumentationWrapper
-@synthesize highlightStrength = _highlightStrength;
 
 + (id) defaultAnimationForKey: (NSString *)key
 {

--- a/Boxer/Documentation Panel/BXDocumentationPanelController.h
+++ b/Boxer/Documentation Panel/BXDocumentationPanelController.h
@@ -15,18 +15,11 @@ NS_ASSUME_NONNULL_BEGIN
 @class BXSession;
 
 @interface BXDocumentationPanelController : NSWindowController <NSPopoverDelegate, BXDocumentationBrowserDelegate>
-{
-    NSPopover *_popover;
-    BXDocumentationBrowser *_popoverBrowser;
-    BXDocumentationBrowser *_windowBrowser;
-    NSSize _maxPopoverSize;
-    
-    BXSession *_session;
-}
 
 #pragma mark - Properties
 
 /// The session whose documents are being displayed in the panel.
+// FIXME: This may be introducing a memory leak by holding a strong reference
 @property (strong, nonatomic, nullable) BXSession *session;
 
 /// Whether the panel is currently visible, either as a popover or as a window.

--- a/Boxer/Documentation Panel/BXDocumentationPanelController.m
+++ b/Boxer/Documentation Panel/BXDocumentationPanelController.m
@@ -31,11 +31,6 @@
 @end
 
 @implementation BXDocumentationPanelController
-@synthesize session = _session;
-@synthesize popover = _popover;
-@synthesize windowBrowser = _windowBrowser;
-@synthesize popoverBrowser = _popoverBrowser;
-@synthesize maxPopoverSize = _maxPopoverSize;
 
 #pragma mark - Initialization and deallocation
 

--- a/Boxer/Input/BXOutputBinding.h
+++ b/Boxer/Input/BXOutputBinding.h
@@ -169,7 +169,7 @@ typedef NS_ENUM(NSInteger, BXAxisPolarity) {
 /// Can be given a delegate to which it will send signals whenever the binding fires.
 @interface BXPeriodicOutputBinding : BXBaseOutputBinding
 
-//The delegate to whom we will send BXPeriodicOutputBindingDelegate messages whenever the binding fires.
+/// The delegate to whom we will send BXPeriodicOutputBindingDelegate messages whenever the binding fires.
 @property (weak, nonatomic) id <BXPeriodicOutputBindingDelegate> delegate;
 
 /// The frequency with which to fire signals. Defaults to 1 / 30.0, i.e. 30 times a second.

--- a/Boxer/Input/BXOutputBinding.h
+++ b/Boxer/Input/BXOutputBinding.h
@@ -50,18 +50,12 @@ typedef NS_ENUM(NSInteger, BXAxisPolarity) {
 
 /// A base class to provide standard functionality to all output bindings. Should not be used directly.
 @interface BXBaseOutputBinding : NSObject <BXOutputBinding>
-{
-    float _previousValue;
-    float _previousNormalizedValue;
-    float _threshold;
-    BOOL _inverted;
-}
 
 /// Input values below this amount will be rounded to 0. This is useful as a deadzone.
-@property (assign, nonatomic) float threshold;
+@property (nonatomic) float threshold;
 
 /// Whether the input values will be flipped.
-@property (assign, nonatomic) BOOL inverted;
+@property (nonatomic) BOOL inverted;
 
 /// The last raw value that was provided to this binding.
 @property (readonly, nonatomic) float latestValue;
@@ -92,21 +86,17 @@ typedef NS_ENUM(NSInteger, BXAxisPolarity) {
 
 /// The base class for all joystick output bindings. Should not be used directly.
 @interface BXBaseEmulatedJoystickBinding : BXBaseOutputBinding
-{
-    id <BXEmulatedJoystick> _joystick;
-}
+
 /// The joystick to which we send input signals.
-@property (strong, nonatomic) id <BXEmulatedJoystick> joystick;
+@property (nonatomic) id <BXEmulatedJoystick> joystick;
 
 @end
 
 
 /// Presses a joystick button when input > 0, releases it when input = 0.
 @interface BXEmulatedJoystickButtonBinding : BXBaseEmulatedJoystickBinding
-{
-    BXEmulatedJoystickButton _button;
-}
-@property (assign, nonatomic) BXEmulatedJoystickButton button;
+
+@property (nonatomic) BXEmulatedJoystickButton button;
 
 + (instancetype) bindingWithJoystick: (id <BXEmulatedJoystick>)joystick button: (BXEmulatedJoystickButton)button;
 
@@ -115,12 +105,9 @@ typedef NS_ENUM(NSInteger, BXAxisPolarity) {
 
 /// Maps the input value as input on a particular joystick axis and polarity.
 @interface BXEmulatedJoystickAxisBinding : BXBaseEmulatedJoystickBinding
-{
-    NSString *_axisName;
-    BXAxisPolarity _polarity;
-}
+
 @property (copy, nonatomic) NSString *axisName;
-@property (assign, nonatomic) BXAxisPolarity polarity;
+@property (nonatomic) BXAxisPolarity polarity;
 
 + (instancetype) bindingWithJoystick: (id <BXEmulatedJoystick>)joystick
                                 axis: (NSString *)axisName
@@ -131,12 +118,9 @@ typedef NS_ENUM(NSInteger, BXAxisPolarity) {
 
 /// Presses a particular hat-switch direction when input > 0, releases it when input = 0.
 @interface BXEmulatedJoystickPOVDirectionBinding : BXBaseEmulatedJoystickBinding
-{
-    NSUInteger _POVNumber;
-    BXEmulatedPOVDirection _POVDirection;
-}
-@property (assign, nonatomic) NSUInteger POVNumber;
-@property (assign, nonatomic) BXEmulatedPOVDirection POVDirection;
+
+@property (nonatomic) NSUInteger POVNumber;
+@property (nonatomic) BXEmulatedPOVDirection POVDirection;
 
 + (instancetype) bindingWithJoystick: (id <BXEmulatedJoystick>)joystick
                                  POV: (NSUInteger)POVNumber
@@ -149,16 +133,12 @@ typedef NS_ENUM(NSInteger, BXAxisPolarity) {
 
 /// Presses a particular keyboard key when input > 0, releases it when input = 0.
 @interface BXEmulatedKeyboardKeyBinding : BXBaseOutputBinding
-{
-    BXEmulatedKeyboard *_keyboard;
-    BXDOSKeyCode _keyCode;
-}
 
 /// The keyboard to which we send key signals.
 @property (strong, nonatomic) BXEmulatedKeyboard *keyboard;
 
 /// The key code to press/release when this binding is activated.
-@property (assign, nonatomic) BXDOSKeyCode keyCode;
+@property (nonatomic) BXDOSKeyCode keyCode;
 
 + (instancetype) bindingWithKeyboard: (BXEmulatedKeyboard *)keyboard keyCode: (BXDOSKeyCode)keyCode;
 
@@ -169,16 +149,12 @@ typedef NS_ENUM(NSInteger, BXAxisPolarity) {
 
 
 @interface BXTargetActionBinding : BXBaseOutputBinding
-{
-    __unsafe_unretained id _target;
-    SEL _pressedAction;
-    SEL _releasedAction;
-}
-@property (assign, nonatomic, nullable) id target;
-@property (assign, nonatomic, nullable) SEL pressedAction;
-@property (assign, nonatomic, nullable) SEL releasedAction;
 
-+ (instancetype) bindingWithTarget: (id)target pressedAction: (SEL)pressedAction releasedAction: (nullable SEL)releasedAction;
+@property (weak, nonatomic, nullable) id target;
+@property (nonatomic, nullable) SEL pressedAction;
+@property (nonatomic, nullable) SEL releasedAction;
+
++ (instancetype) bindingWithTarget: (id)target pressedAction: (nullable SEL)pressedAction releasedAction: (nullable SEL)releasedAction;
 
 @end
 
@@ -192,18 +168,12 @@ typedef NS_ENUM(NSInteger, BXAxisPolarity) {
 /// Stops sending the signal when the input value is 0.
 /// Can be given a delegate to which it will send signals whenever the binding fires.
 @interface BXPeriodicOutputBinding : BXBaseOutputBinding
-{
-    __unsafe_unretained NSTimer *_timer;
-    __unsafe_unretained id <BXPeriodicOutputBindingDelegate> _delegate;
-    NSTimeInterval _period;
-    NSTimeInterval _lastUpdated;
-}
 
-/// The delegate to whom we will send BXPeriodicOutputBindingDelegate messages whenever the binding fires.
-@property (assign, nonatomic, nullable) id <BXPeriodicOutputBindingDelegate> delegate;
+//The delegate to whom we will send BXPeriodicOutputBindingDelegate messages whenever the binding fires.
+@property (weak, nonatomic) id <BXPeriodicOutputBindingDelegate> delegate;
 
 /// The frequency with which to fire signals. Defaults to 1 / 30.0, i.e. 30 times a second.
-@property (assign, nonatomic) NSTimeInterval period;
+@property (nonatomic) NSTimeInterval period;
 
 /// Called whenever the timer fires, with the elapsed time since the previous firing.
 /// Must be implemented by subclasses.
@@ -223,24 +193,18 @@ typedef NS_ENUM(NSInteger, BXAxisPolarity) {
 /// Increments (or decrements) the value of an axis over time.
 /// Useful for mimicking throttle axes that don't return to 0 when released.
 @interface BXEmulatedJoystickAxisAdditiveBinding : BXPeriodicOutputBinding
-{
-    id <BXEmulatedJoystick> _joystick;
-    NSString *_axisName;
-    float _ratePerSecond;
-    float _outputThreshold;
-}
 
 /// The joystick and axis this binding will increment/decrement.
 @property (strong, nonatomic) id <BXEmulatedJoystick> joystick;
 @property (copy, nonatomic) NSString *axisName;
 
 /// Output axis values below this amount will be snapped to zero.
-@property (assign, nonatomic) float outputThreshold;
+@property (nonatomic) float outputThreshold;
 
 /// How much to increment/decrement the axis value by over the course of one second,
 /// while the input value is at maximum. If this is positive, the axis value will increase;
 /// if negative, the axis value will decrease.
-@property (assign, nonatomic) float ratePerSecond;
+@property (nonatomic) float ratePerSecond;
 
 + (instancetype) bindingWithJoystick: (id <BXEmulatedJoystick>)joystick axis: (NSString *)axisName rate: (float)ratePerSecond;
 

--- a/Boxer/Input/BXOutputBinding.m
+++ b/Boxer/Input/BXOutputBinding.m
@@ -27,10 +27,6 @@
 @end
 
 @implementation BXBaseOutputBinding
-@synthesize latestValue = _previousValue;
-@synthesize latestNormalizedValue = _previousNormalizedValue;
-@synthesize threshold = _threshold;
-@synthesize inverted = _inverted;
 
 + (id) binding
 {
@@ -80,12 +76,9 @@
 #pragma mark - Joystick bindings
 
 @implementation BXBaseEmulatedJoystickBinding
-@synthesize joystick = _joystick;
-
 @end
 
 @implementation BXEmulatedJoystickButtonBinding
-@synthesize button = _button;
 
 #pragma mark - Binding behaviour
 
@@ -121,8 +114,6 @@
 
 
 @implementation BXEmulatedJoystickAxisBinding
-@synthesize axisName = _axisName;
-@synthesize polarity = _polarity;
 
 #pragma mark - Binding behaviour
 
@@ -171,8 +162,6 @@
 
 
 @implementation BXEmulatedJoystickPOVDirectionBinding
-@synthesize POVDirection = _POVDirection;
-@synthesize POVNumber = _POVNumber;
 
 #pragma mark - Binding behaviour
 
@@ -216,8 +205,6 @@
 #pragma mark - Keyboard bindings
 
 @implementation BXEmulatedKeyboardKeyBinding
-@synthesize keyCode = _keyCode;
-@synthesize keyboard = _keyboard;
 
 #pragma mark - Binding behaviour
 
@@ -257,7 +244,8 @@
 @interface BXPeriodicOutputBinding ()
 
 //NOTE: timers retain their targets, so we keep a weak reference to the timer to avoid a circular retain.
-@property (assign, nonatomic) NSTimer *timer;
+@property (weak, nonatomic) NSTimer *timer;
+@property (nonatomic) NSTimeInterval lastUpdated;
 
 //Called by the timer. Calculates the elapsed time, calls applyPeriodicUpdateForTimeStep:, and notifies the delegate.
 - (void) _applyPeriodicUpdate;
@@ -268,9 +256,6 @@
 @end
 
 @implementation BXPeriodicOutputBinding
-@synthesize delegate = _delegate;
-@synthesize period = _period;
-@synthesize timer = _timer;
 
 #pragma mark - Binding behaviour
 
@@ -287,9 +272,9 @@
     if (self.latestNormalizedValue > 0)
     {
         NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
-        NSTimeInterval elapsedTime = now - _lastUpdated;
+        NSTimeInterval elapsedTime = now - self.lastUpdated;
         [self applyPeriodicUpdateForTimeStep: elapsedTime];
-        _lastUpdated = now;
+        self.lastUpdated = now;
         
         [self.delegate outputBindingDidUpdate: self];
     }
@@ -305,7 +290,7 @@
 {
     if (!self.timer)
     {
-        _lastUpdated = [NSDate timeIntervalSinceReferenceDate];
+        self.lastUpdated = [NSDate timeIntervalSinceReferenceDate];
         self.timer = [NSTimer scheduledTimerWithTimeInterval: self.period
                                                       target: self
                                                     selector: @selector(_applyPeriodicUpdate)
@@ -341,10 +326,6 @@
 
 
 @implementation BXEmulatedJoystickAxisAdditiveBinding
-@synthesize ratePerSecond = _ratePerSecond;
-@synthesize joystick = _joystick;
-@synthesize axisName = _axisName;
-@synthesize outputThreshold = _outputThreshold;
 
 #pragma mark - Binding behaviour
 
@@ -384,9 +365,6 @@
 
 
 @implementation BXTargetActionBinding
-@synthesize target = _target;
-@synthesize pressedAction = _pressedAction;
-@synthesize releasedAction = _releasedAction;
 
 + (id) bindingWithTarget: (id)target pressedAction: (SEL)pressedAction releasedAction: (SEL)releasedAction
 {

--- a/Boxer/Inspector Panel/BXDriveItem.h
+++ b/Boxer/Inspector Panel/BXDriveItem.h
@@ -11,20 +11,6 @@
 /// BXDriveItem represents each drive in the list and acts
 /// as a view controller for its corresponding BXDriveItemView.
 @interface BXDriveItem : BXCollectionItem
-{
-    BOOL _importing;
-    
-    NSProgressIndicator *_progressMeter;
-    NSTextField *_progressMeterLabel;
-    NSTextField *_titleLabel;
-    NSTextField *_typeLabel;
-    NSButton *_toggleButton;
-    NSButton *_revealButton;
-    NSButton *_importButton;
-    NSImageView *_icon;
-    NSTextField *_letterLabel;
-    NSButton *_cancelButton;
-}
 
 #pragma mark - Outlet properties
 @property (strong, nonatomic) IBOutlet NSProgressIndicator *progressMeter;

--- a/Boxer/Inspector Panel/BXDriveItem.m
+++ b/Boxer/Inspector Panel/BXDriveItem.m
@@ -24,17 +24,6 @@
 @end
 
 @implementation BXDriveItem
-@synthesize importing = _importing;
-@synthesize titleLabel = _titleLabel;
-@synthesize typeLabel = _typeLabel;
-@synthesize progressMeter = _progressMeter;
-@synthesize progressMeterLabel = _progressMeterLabel;
-@synthesize toggleButton = _toggleButton;
-@synthesize revealButton = _revealButton;
-@synthesize importButton = _importButton;
-@synthesize cancelButton = _cancelButton;
-@synthesize icon = _icon;
-@synthesize letterLabel = _letterLabel;
 
 - (void) viewDidLoad
 {

--- a/Boxer/Inspector Panel/BXDriveList.h
+++ b/Boxer/Inspector Panel/BXDriveList.h
@@ -31,16 +31,10 @@
 
 /// A custom appearance for control buttons within drive item views.
 @interface BXDriveItemButtonCell : BXThemedButtonCell
-{
-	BOOL _hovered;
-}
 @property (assign, nonatomic, getter=isHovered) BOOL hovered;
 @end
 
 
 /// A custom appearance for drive labels.
 @interface BXDriveLetterCell : NSTextFieldCell <BXThemable>
-{
-    NSString *_themeKey;
-}
 @end

--- a/Boxer/Inspector Panel/BXDriveList.m
+++ b/Boxer/Inspector Panel/BXDriveList.m
@@ -27,7 +27,6 @@
 
 
 @implementation BXDriveItemButtonCell
-@synthesize hovered = _hovered;
 
 + (NSString *) defaultThemeKey
 {

--- a/Boxer/Inspector Panel/BXDrivePanelController.h
+++ b/Boxer/Inspector Panel/BXDrivePanelController.h
@@ -15,15 +15,6 @@
 
 /// \c BXDrivePanelController manages the Drives panel of the Inspector window.
 @interface BXDrivePanelController : NSViewController <ADBOperationDelegate, NSWindowDelegate, NSDraggingDestination, NSDraggingSource>
-{
-	NSSegmentedControl *_driveControls;
-	NSMenu *_driveActionsMenu;
-	BXDriveList *_driveList;
-    
-    NSIndexSet *_selectedDriveIndexes;
-    
-    NSWindow *_driveRemovalDropzone;
-}
 
 #pragma mark -
 #pragma mark Properties

--- a/Boxer/Inspector Panel/BXDrivePanelController.m
+++ b/Boxer/Inspector Panel/BXDrivePanelController.m
@@ -35,11 +35,11 @@ enum {
 #pragma mark -
 #pragma mark Implementation
 
+@interface BXDrivePanelController ()
+@property (strong, nonatomic) NSWindow *driveRemovalDropzone;
+@end
+
 @implementation BXDrivePanelController
-@synthesize driveControls = _driveControls;
-@synthesize driveActionsMenu = _driveActionsMenu;
-@synthesize driveList = _driveList;
-@synthesize selectedDriveIndexes = _selectedDriveIndexes;
 
 #pragma mark -
 #pragma mark Initialization and teardown
@@ -101,7 +101,7 @@ enum {
     
     self.selectedDriveIndexes = nil;
     
-    [_driveRemovalDropzone close]; _driveRemovalDropzone = nil;
+    [self.driveRemovalDropzone close]; self.driveRemovalDropzone = nil;
 }
 
 - (void) observeValueForKeyPath: (NSString *)keyPath
@@ -561,7 +561,7 @@ enum {
     if (!session)
         return NSDragOperationNone;
     
-    if (_driveRemovalDropzone && sender.draggingDestinationWindow == _driveRemovalDropzone)
+    if (self.driveRemovalDropzone && sender.draggingDestinationWindow == self.driveRemovalDropzone)
     {
         if (sender.draggingSource == self)
         {
@@ -602,7 +602,7 @@ enum {
     
     if (draggedURLs.count)
     {
-        if (_driveRemovalDropzone && sender.draggingDestinationWindow == _driveRemovalDropzone)
+        if (self.driveRemovalDropzone && sender.draggingDestinationWindow == self.driveRemovalDropzone)
         {
             BOOL removed = [self _unmountDrives: self.selectedDrives
                                         options: BXDefaultDriveUnmountOptions | BXDriveRemoveExistingFromQueue];
@@ -677,41 +677,41 @@ enum {
 - (void) draggingSession: (NSDraggingSession *)session willBeginAtPoint: (NSPoint)screenPoint
 {
     //Create a transparent backing window the first time we need it
-    if (!_driveRemovalDropzone)
+    if (!self.driveRemovalDropzone)
     {
         NSScreen *screen = self.view.window.screen;
-        _driveRemovalDropzone = [[NSWindow alloc] initWithContentRect: screen.frame
+        self.driveRemovalDropzone = [[NSWindow alloc] initWithContentRect: screen.frame
                                                             styleMask: NSBorderlessWindowMask
                                                               backing: NSBackingStoreBuffered
                                                                 defer: YES
                                                                screen: screen];
         
-        _driveRemovalDropzone.backgroundColor = [NSColor clearColor];
-        _driveRemovalDropzone.opaque = NO;
-        _driveRemovalDropzone.ignoresMouseEvents = NO; //Will default to YES for fully transparent windows
-        _driveRemovalDropzone.hidesOnDeactivate = YES;
-        _driveRemovalDropzone.releasedWhenClosed = YES;
-        _driveRemovalDropzone.level = NSNormalWindowLevel;
-        _driveRemovalDropzone.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces;
-        _driveRemovalDropzone.delegate = self;
+        self.driveRemovalDropzone.backgroundColor = [NSColor clearColor];
+        self.driveRemovalDropzone.opaque = NO;
+        self.driveRemovalDropzone.ignoresMouseEvents = NO; //Will default to YES for fully transparent windows
+        self.driveRemovalDropzone.hidesOnDeactivate = YES;
+        self.driveRemovalDropzone.releasedWhenClosed = YES;
+        self.driveRemovalDropzone.level = NSNormalWindowLevel;
+        self.driveRemovalDropzone.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces;
+        self.driveRemovalDropzone.delegate = self;
         
-        [_driveRemovalDropzone registerForDraggedTypes: @[NSFilenamesPboardType]];
+        [self.driveRemovalDropzone registerForDraggedTypes: @[NSFilenamesPboardType]];
     }
     
     //Place the dropzone behind all of Boxer's windows, but on top of windows in other applications.
     NSInteger furthestWindowNumber = -1;
     for (NSWindow *window in [NSApp windows])
     {
-        if (window != _driveRemovalDropzone && window.isVisible
-            && window.level == _driveRemovalDropzone.level
+        if (window != self.driveRemovalDropzone && window.isVisible
+            && window.level == self.driveRemovalDropzone.level
             && window.windowNumber > furthestWindowNumber)
             furthestWindowNumber = window.windowNumber;
     }
     
     if (furthestWindowNumber > -1)
-        [_driveRemovalDropzone orderWindow: NSWindowBelow relativeTo: furthestWindowNumber];
+        [self.driveRemovalDropzone orderWindow: NSWindowBelow relativeTo: furthestWindowNumber];
     else
-        [_driveRemovalDropzone orderWindow: NSWindowBelow relativeTo: self.view.window.windowNumber];
+        [self.driveRemovalDropzone orderWindow: NSWindowBelow relativeTo: self.view.window.windowNumber];
 }
 
 - (void) draggingSession: (NSDraggingSession *)session movedToPoint: (NSPoint)screenPoint
@@ -732,7 +732,7 @@ enum {
         item.view.hidden = NO;
     }];
     
-    [_driveRemovalDropzone orderOut: self];
+    [self.driveRemovalDropzone orderOut: self];
 }
 
 @end

--- a/Boxer/Inspector Panel/BXGameboxPanelController.h
+++ b/Boxer/Inspector Panel/BXGameboxPanelController.h
@@ -15,10 +15,7 @@
 /// menu with the available programs in the current gamebox (if any), and synchronising its selection
 /// with the default program of the gamebox.
 @interface BXGameboxPanelController : NSViewController <NSOpenSavePanelDelegate>
-{
-    NSPopUpButton *_programSelector;
-    NSObjectController *_sessionMediator;
-}
+
 /// The program selector popup button we populate.
 @property (strong, nonatomic) IBOutlet NSPopUpButton *programSelector;
 /// The NIB's object-controller proxy for the current session.

--- a/Boxer/Inspector Panel/BXGameboxPanelController.m
+++ b/Boxer/Inspector Panel/BXGameboxPanelController.m
@@ -42,8 +42,6 @@ enum {
 #pragma mark Implementation
 
 @implementation BXGameboxPanelController
-@synthesize programSelector = _programSelector;
-@synthesize sessionMediator = _sessionMediator;
 
 - (BXSession *) session
 {

--- a/Boxer/Inspector Panel/BXJoystickItem.h
+++ b/Boxer/Inspector Panel/BXJoystickItem.h
@@ -8,11 +8,6 @@
 #import "BXCollectionItemView.h"
 
 @interface BXJoystickItem : BXCollectionItem
-{
-    NSTextField *_titleLabel;
-    NSTextField *_descriptionLabel;
-    NSImageView *_icon;
-}
 
 @property (strong, nonatomic, null_unspecified) IBOutlet NSTextField *titleLabel;
 @property (strong, nonatomic, null_unspecified) IBOutlet NSTextField *descriptionLabel;

--- a/Boxer/Inspector Panel/BXJoystickItem.m
+++ b/Boxer/Inspector Panel/BXJoystickItem.m
@@ -16,9 +16,6 @@
 @end
 
 @implementation BXJoystickItem
-@synthesize titleLabel = _titleLabel;
-@synthesize descriptionLabel = _descriptionLabel;
-@synthesize icon = _icon;
 
 - (void) setSelected: (BOOL)selected
 {

--- a/Boxer/Printing/BXPrintSession.h
+++ b/Boxer/Printing/BXPrintSession.h
@@ -11,22 +11,6 @@
 /// BXPrintSession represents a single multi-page session into which an emulated printer
 /// (such as <code>BXEmulatedPrinter</code>) may print.
 @interface BXPrintSession : NSObject
-{
-    BOOL _finished;
-    BOOL _pageInProgress;
-    NSUInteger _numPages;
-    NSSize _previewDPI;
-    
-    CGContextRef _CGPDFContext;
-    CGDataConsumerRef _PDFDataConsumer;
-    NSGraphicsContext *_PDFContext;
-    NSMutableData *_PDFData;
-    
-    NSMutableArray *_pagePreviews;
-    NSGraphicsContext *_previewContext;
-    NSBitmapImageRep *_previewCanvas;
-    void *_previewCanvasBacking;
-}
 
 #pragma mark -
 #pragma mark Properties

--- a/Boxer/Printing/BXPrintSession.m
+++ b/Boxer/Printing/BXPrintSession.m
@@ -35,16 +35,17 @@
 
 
 @implementation BXPrintSession
-@synthesize PDFContext = _PDFContext;
-@synthesize previewContext = _previewContext;
-@synthesize _previewCanvas = _previewCanvas;
+{
+	CGContextRef _CGPDFContext;
+	CGDataConsumerRef _PDFDataConsumer;
+	NSMutableData *_PDFData;
+	
+	NSMutableArray *_pagePreviews;
+	void *_previewCanvasBacking;
+}
+
 @synthesize _mutablePDFData = _PDFData;
 @synthesize _mutablePagePreviews = _pagePreviews;
-
-@synthesize pageInProgress = _pageInProgress;
-@synthesize finished = _finished;
-@synthesize numPages = _numPages;
-@synthesize previewDPI = _previewDPI;
 
 #pragma mark -
 #pragma mark Starting and ending sessions

--- a/Boxer/Printing/BXPrintStatusPanelController.h
+++ b/Boxer/Printing/BXPrintStatusPanelController.h
@@ -13,14 +13,6 @@
 @class BXPrintPreview;
 
 @interface BXPrintStatusPanelController : NSWindowController
-{
-    BXEmulatedPrinterPort _activePrinterPort;
-    NSString *_localizedPaperName;
-    BOOL _inProgress;
-    NSUInteger _numPages;
-    
-    BXPrintPreview *_preview;
-}
 
 /// The number of pages printed so far, including the current page.
 @property (assign, nonatomic) NSUInteger numPages;
@@ -55,20 +47,6 @@
 
 
 @interface BXPrintPreview : NSView <CALayerDelegate>
-{
-    CALayer *_currentPage;
-    CALayer *_previousPage;
-    CALayer *_paperFeed;
-    CALayer *_head;
-    
-    CGImageRef _paperTexture;
-    
-    CGFloat _headOffset;
-    CGFloat _feedOffset;
-    
-    CGSize _pageSize;
-    CGSize _dpi;
-}
 
 //The preview images for the current and previous page.
 @property (strong, nonatomic) NSImage *currentPagePreview;

--- a/Boxer/Printing/BXPrintStatusPanelController.m
+++ b/Boxer/Printing/BXPrintStatusPanelController.m
@@ -12,11 +12,6 @@
 #import <QuartzCore/QuartzCore.h>
 
 @implementation BXPrintStatusPanelController
-@synthesize numPages = _numPages;
-@synthesize inProgress = _inProgress;
-@synthesize activePrinterPort = _activePrinterPort;
-@synthesize localizedPaperName = _localizedPaperName;
-@synthesize preview = _preview;
 
 - (void) windowDidLoad
 {
@@ -143,16 +138,9 @@
 @end
 
 @implementation BXPrintPreview
-
-@synthesize currentPage = _currentPage;
-@synthesize previousPage = _previousPage;
-@synthesize paperFeed = _paperFeed;
-@synthesize head = _head;
-
-@synthesize headOffset = _headOffset;
-@synthesize feedOffset = _feedOffset;
-@synthesize pageSize = _pageSize;
-@synthesize dpi = _dpi;
+{
+	CGImageRef _paperTexture;
+}
 
 - (void) awakeFromNib
 {

--- a/Boxer/Rendering/BXFrameRateCounterLayer.h
+++ b/Boxer/Rendering/BXFrameRateCounterLayer.h
@@ -11,9 +11,6 @@
 /// \c BXFrameRateCounterLayer is a cheap and dirty subclass of CATextLayer to format a provided/bound
 /// frame rate as a suitable string for display.
 @interface BXFrameRateCounterLayer : CATextLayer
-{
-	CGFloat frameRate;
-}
-@property (assign, nonatomic) CGFloat frameRate;
+@property (nonatomic) CGFloat frameRate;
 
 @end

--- a/Boxer/Rendering/BXFrameRateCounterLayer.m
+++ b/Boxer/Rendering/BXFrameRateCounterLayer.m
@@ -9,11 +9,10 @@
 #import "BXFrameRateCounterLayer.h"
 
 @implementation BXFrameRateCounterLayer
-@synthesize frameRate;
 
 - (void) setFrameRate: (CGFloat)newRate
 {
-	frameRate = newRate;	
+	_frameRate = newRate;	
 	[self setString: [NSString stringWithFormat: @"%0.02f fps", newRate]];
 }
 

--- a/Boxer/Rendering/BXLayerBackedRenderingView.h
+++ b/Boxer/Rendering/BXLayerBackedRenderingView.h
@@ -20,12 +20,8 @@
 /// - All rendering occurs on the main thread, causing lag instead of dropped frames during heavy computation
 /// - It slows down whenever notification bezels appear over it
 @interface BXLayerBackedRenderingView : NSView <BXFrameRenderingView, CALayerDelegate>
-{
-    BOOL _managesViewport;
-    NSSize _maxViewportSize;
-}
 
-@property (assign, nonatomic) BOOL managesViewport;
-@property (assign, nonatomic) NSSize maxViewportSize;
+@property (nonatomic) BOOL managesViewport;
+@property (nonatomic) NSSize maxViewportSize;
 
 @end

--- a/Boxer/Rendering/BXLayerBackedRenderingView.m
+++ b/Boxer/Rendering/BXLayerBackedRenderingView.m
@@ -12,18 +12,10 @@
 
 @property (strong, nonatomic) BXRenderingLayer *layer;
 
-//Returns the rectangular region of the view into which the specified frame will be drawn.
-//This will be equal to the view bounds if managesAspectRatio is NO; otherwise, it will
-//be a rectangle of the same aspect ratio as the frame fitted to within the current or maximum
-//viewport size (whichever is smaller).
-//- (NSRect) viewportForFrame: (BXVideoFrame *)frame;
-
 @end
 
 
 @implementation BXLayerBackedRenderingView
-@synthesize managesViewport = _managesViewport;
-@synthesize maxViewportSize = _maxViewportSize;
 
 - (void) awakeFromNib
 {

--- a/Boxer/Rendering/BXRenderingLayer.h
+++ b/Boxer/Rendering/BXRenderingLayer.h
@@ -14,17 +14,8 @@
 
 /// \c BXRenderingLayer is the OpenGL layer used by BXLayerBackedRenderingView for rendering its content.
 @interface BXRenderingLayer : CAOpenGLLayer
-{
-    BXVideoFrame *_currentFrame;
-    BXRenderingStyle _renderingStyle;
-    NSMutableArray *_renderers;
-    
-    BXBasicRenderer *_lastRenderer;
-    CFTimeInterval _lastRenderTime;
-    
-}
 
-@property (assign, nonatomic) BXRenderingStyle renderingStyle;
+@property (nonatomic) BXRenderingStyle renderingStyle;
 @property (strong, readonly, nonatomic) BXVideoFrame *currentFrame;
 
 - (void) updateWithFrame: (BXVideoFrame *)currentFrame;

--- a/Other Sources/ADBToolkit/ADBUndoExtensions.h
+++ b/Other Sources/ADBToolkit/ADBUndoExtensions.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Set/retrieve the delegate that will provide this object with an undo manager.
 /// The receiver should not retain the delegate.
-@property (readwrite, assign, nullable) id <ADBUndoDelegate> undoDelegate;
+@property (weak, nonatomic) id <ADBUndoDelegate> undoDelegate;
 
 @end
 


### PR DESCRIPTION
Based off https://github.com/alunbestor/Boxer/tree/64bit/master, which is a clone of https://github.com/MaddTheSane/Boxer/commit/234a6a7859ad2a2499eef59be345eacc7d5d79f8

This PR cleans up a swathe of classes to do the following:
- remove manual property synthesis (i.e. `@synthesize propertyName = _ivarName`) except for properties defined in protocols.
- remove manual ivar declarations that are already declared by properties.
- move any remaining ivar declarations into the `.m` and `.mm` files.

This PR also clarifies a bunch of redundant or inappropriate `@property` attributes, according to the following rules:
- remove `assign` from non-object properties *(this is inferred)*
- add `nonatomic` to properties that are not expected to be thread-safe *(almost all of them)*
- add `atomic` to properties that actually *are* expected to be thread-safe *(mostly around async operations and rendering)*
- remove `nullable` from `weak` properties *(this is implied)*
- remove `copy`, `weak` and `strong` from computed `readonly` properties *(these attributes are only relevant for stored properties, not computed ones)*
- mark `delegate`-style properties as `weak`, or in rare cases `unsafe_unretained` *(where code clearly relies on the property having a value)*
- mark `weak` IBOutlets as `strong` instead *(this is now Apple's recommended practice)*

Some classes with complex sets of ivars (e.g. `BXSession` and `BXEmulator`) have not yet been migrated, as they need additional work to expose necessary properties to subclasses/subcomponents. I have no doubt also missed a bunch of property attributes too.