### PR TITLE
Fix exception when awakening launch panel

### DIFF
--- a/Boxer/DOS window/BXLaunchPanelController.m
+++ b/Boxer/DOS window/BXLaunchPanelController.m
@@ -46,14 +46,21 @@
 	BOOL _shouldUpdateImmediately;
 }
 
-- (void) awakeFromNib
-{
-    self.allProgramRows = [NSMutableArray array];
-    self.favoriteProgramRows = [NSMutableArray array];
-    self.recentProgramRows = [NSMutableArray array];
-    self.displayedRows = [NSMutableArray array];
-    self.filterKeywords = [NSMutableArray array];
+- (instancetype) initWithCoder: (NSCoder *)coder {
+    self = [super initWithCoder: coder];
+    if (self) {
+        _allProgramRows = [NSMutableArray array];
+        _favoriteProgramRows = [NSMutableArray array];
+        _recentProgramRows = [NSMutableArray array];
+        _displayedRows = [NSMutableArray array];
+        _filterKeywords = [NSMutableArray array];
+    }
+    return self;
+}
 
+- (void) viewDidLoad {
+    [super viewDidLoad];
+    
     //These attributes are unsupported in 10.6 and so cannot be defined in the XIB.
     if ([self.launcherScrollView respondsToSelector: @selector(setScrollerKnobStyle:)])
         self.launcherScrollView.scrollerKnobStyle = NSScrollerKnobStyleLight;


### PR DESCRIPTION
BXLaunchPanelController was setting its internal properties too late and triggering KVO too early in its lifecycle, triggering a collection view exception when opening a plain DOS window.

This may have been a regression from https://github.com/alunbestor/Boxer/pull/78, but since that PR did not touch the lines responsible I have no idea why it wasn't always crashing.