### PR TITLE
Fix launcher exception caused by incorrect property synthesis

### DIFF
--- a/Boxer/BXCDImageImport.m
+++ b/Boxer/BXCDImageImport.m
@@ -20,6 +20,8 @@ NSString * const BXCDImageImportErrorDomain = @"BXCDImageImportErrorDomain";
 #pragma mark Implementations
 
 @implementation BXCDImageImport
+@synthesize currentProgress = _currentProgress;
+@synthesize indeterminate = _indeterminate;
 
 @synthesize drive = _drive;
 @synthesize destinationFolderURL	= _destinationFolderURL;

--- a/Boxer/BXEmulatorErrors.mm
+++ b/Boxer/BXEmulatorErrors.mm
@@ -297,6 +297,8 @@ NSString * const BXEmulatorUnrecoverableException = @"BXEmulatorUnrecoverableExc
 
 
 @implementation BXEmulatorException
+@synthesize callStackReturnAddresses = _callStackReturnAddresses;
+@synthesize callStackSymbols = _callStackSymbols;
 
 + (id) exceptionWithName: (NSString *)name
        originalException: (boxer_emulatorException *)cppException

--- a/Boxer/DOS window/BXLaunchPanelController.m
+++ b/Boxer/DOS window/BXLaunchPanelController.m
@@ -813,6 +813,7 @@
 
 
 @implementation BXLauncherItem
+@synthesize menu = _menu;
 
 - (id) copyWithZone: (NSZone *)zone
 {


### PR DESCRIPTION
https://github.com/alunbestor/Boxer/pull/78 deleted a handful of explicit property synthesis declarations that turned out to be actually necessary and were generating warnings.

One of these was `BXLauncherItem.menu`, which was shadowing a parent property - without explicit synthesis, the parent property was "winning", resulting in an exception being thrown when the launch list tried to populate itself and got an invalid menu reference.