### PR TITLE
Fix window backgrounds

### DIFF
--- a/Boxer/BXBlueprintBackgroundView.m
+++ b/Boxer/BXBlueprintBackgroundView.m
@@ -14,7 +14,7 @@
 
 - (void) _drawBlueprintInRect: (NSRect)dirtyRect
 {	
-	NSColor *blueprintColor = [NSColor colorWithPatternImage: [NSImage imageNamed: @"Blueprint.jpg"]];
+	NSColor *blueprintColor = [NSColor colorWithPatternImage: [NSImage imageNamed: @"Blueprint"]];
 	NSSize patternSize		= blueprintColor.patternImage.size;
 	NSSize viewSize			= self.bounds.size;
 	NSPoint patternOffset	= [NSView focusView].offsetFromWindowOrigin;

--- a/Boxer/BXBlueprintPanel.m
+++ b/Boxer/BXBlueprintPanel.m
@@ -17,7 +17,7 @@
 
 - (void) _drawBlueprintInRect: (NSRect)dirtyRect
 {
-    NSImage *pattern = [NSImage imageNamed: @"Blueprint.jpg"];
+    NSImage *pattern = [NSImage imageNamed: @"Blueprint"];
 	NSColor *blueprintColor = [NSColor colorWithPatternImage: pattern];
     
 	NSPoint offset = [NSView focusView].offsetFromWindowOrigin;

--- a/Boxer/BXFilterGallery.m
+++ b/Boxer/BXFilterGallery.m
@@ -15,7 +15,7 @@
 
 - (void) drawRect: (NSRect)dirtyRect
 {
-	NSImage *wallpaper	= [NSImage imageNamed: @"GalleryBkg.jpg"];
+	NSImage *wallpaper	= [NSImage imageNamed: @"GalleryBkg"];
 	NSColor *pattern	= [NSColor colorWithPatternImage: wallpaper];
 	
 	NSSize patternSize	= wallpaper.size;


### PR DESCRIPTION
The backgrounds of the import window and display preferences inadvertently broke after images were migrated to Asset catalogs. This is because the code for those views still referenced "Filename.jpg" as the image name, but assets have no file extensions.

### Before
<img width="592" alt="screen shot 2018-04-29 at 22 51 12" src="https://user-images.githubusercontent.com/177422/39414247-5c26860e-4c03-11e8-9007-8512ec853ffe.png">

### After
<img width="592" alt="screen shot 2018-04-29 at 23 17 10" src="https://user-images.githubusercontent.com/177422/39414255-75bd4ce2-4c03-11e8-950c-6280318249e9.png">